### PR TITLE
Add substitution_args $(arg foo) support to xacro

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -41,7 +41,10 @@ import xml
 from xml.dom.minidom import parse
 
 from roslaunch import substitution_args
+from rosgraph.names import load_mappings
 
+# Dictionary of subtitution args
+substitution_args_context = {}
 
 class XacroException(Exception):
     pass
@@ -52,8 +55,7 @@ def isnumber(x):
 
 
 def eval_extension(str):
-    return substitution_args.resolve_args(str, resolve_anon=False)
-
+    return substitution_args.resolve_args(str, context=substitution_args_context, resolve_anon=False)
 
 # Better pretty printing of xml
 # Taken from http://ronrothman.com/public/leftbraned/xml-dom-minidom-toprettyxml-and-silly-whitespace/
@@ -556,6 +558,9 @@ def main():
     if len(args) < 1:
         print("No input given")
         print_usage(2)
+
+    # Process substitution args
+    substitution_args_context['arg'] = load_mappings(sys.argv)
 
     f = open(args[0])
     doc = None

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -533,6 +533,9 @@ def print_usage(exit_code=0):
     print("       %s --includes   Only evalutes includes" % 'xacro.py')
     sys.exit(exit_code)
 
+def set_substitution_args_context(context = {}):
+    substitution_args_context['arg'] = context
+
 
 def main():
     try:
@@ -560,7 +563,7 @@ def main():
         print_usage(2)
 
     # Process substitution args
-    substitution_args_context['arg'] = load_mappings(sys.argv)
+    set_substitution_args_context(load_mappings(sys.argv))
 
     f = open(args[0])
     doc = None

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -7,6 +7,9 @@ import unittest
 import xacro
 from xml.dom.minidom import parse, parseString
 import xml.dom
+import os.path
+from rosgraph.names import load_mappings
+from xacro import set_substitution_args_context
 
 def all_attributes_match(a, b):
     if len(a.attributes) != len(b.attributes):
@@ -127,6 +130,20 @@ class TestXacro(unittest.TestCase):
             xml_matches(
                 quick_xacro('''<a><f v="${0.9 / 2 - 0.2}" /></a>'''),
                 '''<a><f v="0.25" /></a>'''))
+
+    def test_substitution_args_find(self):
+        self.assertTrue(
+            xml_matches(
+                quick_xacro('''<a><f v="$(find xacro)/test/test_xacro.py" /></a>'''),
+                '''<a><f v="'''+os.path.abspath(__file__)+'''" /></a>'''))
+
+    def test_substitution_args_arg(self):
+        set_substitution_args_context(load_mappings(['sub_arg:=my_arg']))
+        self.assertTrue(
+            xml_matches(
+                quick_xacro('''<a><f v="$(arg sub_arg)" /></a>'''),
+                '''<a><f v="my_arg" /></a>'''))
+        set_substitution_args_context({})
 
     def test_escaping_dollar_braces(self):
         self.assertTrue(


### PR DESCRIPTION
This fixes #3 (https://code.ros.org/trac/ros-pkg/ticket/5420)
