### PR TITLE
xacro conditional blocks

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -504,6 +504,26 @@ def eval_all(root, macros, symbols):
                     raise XacroException("Block \"%s\" was never declared" % name)
 
                 node = None
+            elif node.tagName == 'if' or node.tagName == 'xacro:if':
+                value = eval_text(node.getAttribute('value'), symbols)
+                if value == 1 or value == 'true':
+                    for e in list(child_elements(node)):
+                        cloned = node.cloneNode(deep = True)
+                        eval_all(cloned, macros, symbols)
+                        node.parentNode.insertBefore(e, node)
+                elif value != 0 and value != 'false':
+                    raise XacroException("Xacro conditional evaluated to \"%s\". Acceptable evaluations are one of [\"1\",\"true\",\"0\",\"false\"]" % value)
+                node.parentNode.removeChild(node)
+            elif node.tagName == 'unless' or node.tagName == 'xacro:unless':
+                value = eval_text(node.getAttribute('value'), symbols)
+                if value == 0 or value == 'false':
+                    for e in list(child_elements(node)):
+                        cloned = node.cloneNode(deep = True)
+                        eval_all(cloned, macros, symbols)
+                        node.parentNode.insertBefore(e, node)
+                elif value != 1 and value != 'true':
+                    raise XacroException("Xacro conditional evaluated to \"%s\". Acceptable evaluations are one of [\"1\",\"true\",\"0\",\"false\"]" % value)
+                node.parentNode.removeChild(node)
             else:
                 # Evals the attributes
                 for at in node.attributes.items():

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -599,7 +599,7 @@ def main():
     finally:
         f.close()
 
-    process_includes(doc, os.path.dirname(sys.argv[1]))
+    process_includes(doc, os.path.dirname(args[0]))
     if just_deps:
         for inc in all_includes:
             sys.stdout.write(inc + " ")


### PR DESCRIPTION
resubmitting pull request https://github.com/ros/xacro/pull/7 to be merged into hydro-devel

---

This patch allows adding conditionals to xacro with the following syntax. This is useful in the case of configurable robots or loading different gazebo plugins.

```
<xacro:if value="<expression/substitution_arg>">
  <... some xml code here ...>
</xacro:if>
<xacro:unless value="<expression/substitution_arg>">
  <... some xml code here ...>
</xacro:unless>
```

The expression needs to evaluate to "0", "true", "1" or "false", otherwise an error will be thrown. Additionally, the conditional has no effect on macro or property definitions, and is only used while constructing the final xml.

The pull request also includes a minor bug fix. https://github.com/piyushk/xacro/commit/5c0cbd7e939bf8dc782d2914003d7ffd3f25788f
