### PR TITLE
Xacro should not use plain 'include' tags but only namespaced ones.

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -217,8 +217,11 @@ def process_includes(doc, base_dir):
             if elt.tagName == 'include':
 
                 # check if there is any element within the <include> tag. mostly we are concerned 
-                # with Gazebo's <uri> element, but it could be anything
-                if elt.childNodes:
+                # with Gazebo's <uri> element, but it could be anything. also, make sure the child
+                # nodes aren't just a single Text node, which is still considered a deprecated 
+                # instance
+                if elt.childNodes and not (len(elt.childNodes) == 1 and 
+                                           elt.childNodes[0].nodeType == elt.TEXT_NODE):
                     # this is not intended to be a xacro element, so we can ignore it
                     is_include = False
                 else:

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -201,7 +201,9 @@ def process_includes(doc, base_dir):
     previous = doc.documentElement
     elt = next_element(previous)
     while elt:
-        if elt.tagName == 'include' or elt.tagName == 'xacro:include':
+        # Xacro should not use plain 'include' tags but only namespaced ones. Causes conflicts with
+        # other XML elements includeing Gazebo's SDF format
+        if elt.tagName == 'xacro:include': 
             filename = eval_text(elt.getAttribute('filename'), {})
             if not os.path.isabs(filename):
                 filename = os.path.join(base_dir, filename)

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -215,10 +215,11 @@ def process_includes(doc, base_dir):
             is_include = True
             # Temporary fix for ROS Hydro and the xacro include scope problem
             if elt.tagName == 'include':
-                check_next = next_element(elt)
-                # check if there is a <uri> element within the <include> tag
-                if check_next.tagName == 'uri':
-                    # this is a correct gazebo element, so we can ignore it
+
+                # check if there is any element within the <include> tag. mostly we are concerned 
+                # with Gazebo's <uri> element, but it could be anything
+                if elt.childNodes:
+                    # this is not intended to be a xacro element, so we can ignore it
                     is_include = False
                 else:
                     # throw a deprecated warning

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -202,7 +202,7 @@ def process_includes(doc, base_dir):
     elt = next_element(previous)
     while elt:
         # Xacro should not use plain 'include' tags but only namespaced ones. Causes conflicts with
-        # other XML elements includeing Gazebo's SDF format
+        # other XML elements including Gazebo's <gazebo> extensions
         if elt.tagName == 'xacro:include': 
             filename = eval_text(elt.getAttribute('filename'), {})
             if not os.path.isabs(filename):

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -195,7 +195,7 @@ def child_elements(elt):
 all_includes = []
 
 # Deprecated message for <include> tags that don't have <xacro:include> prepended:
-deprecated_include_msg = """DEPRECATED IN GROOVY/HYDRO:
+deprecated_include_msg = """DEPRECATED IN HYDRO:
   The <include> tag should be prepended with 'xacro' if that is the intended use 
   of it, such as <xacro:include ...>. Use the following script to fix incorrect
   xacro includes:
@@ -213,7 +213,7 @@ def process_includes(doc, base_dir):
         if elt.tagName == 'xacro:include' or elt.tagName == 'include': 
 
             is_include = True
-            # Temporary fix for ROS Groovy and Hydro and the xacro include scope problem
+            # Temporary fix for ROS Hydro and the xacro include scope problem
             if elt.tagName == 'include':
                 check_next = next_element(elt)
                 # check if there is a <uri> element within the <include> tag

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -194,6 +194,12 @@ def child_elements(elt):
 
 all_includes = []
 
+# Deprecated message for <include> tags that don't have <xacro:include> prepended:
+deprecated_include_msg = """DEPRECATED IN GROOVY/HYDRO:
+  The <include> tag should be prepended with 'xacro' if that is the intended use 
+  of it, such as <xacro:include ...>. Use the following script to fix incorrect
+  xacro includes:
+     sed -i 's/<include/<xacro:include/g' `find . -iname *.xacro`"""
 
 ## @throws XacroException if a parsing error occurs with an included document
 def process_includes(doc, base_dir):
@@ -203,7 +209,23 @@ def process_includes(doc, base_dir):
     while elt:
         # Xacro should not use plain 'include' tags but only namespaced ones. Causes conflicts with
         # other XML elements including Gazebo's <gazebo> extensions
-        if elt.tagName == 'xacro:include': 
+        is_include = False
+        if elt.tagName == 'xacro:include' or elt.tagName == 'include': 
+
+            is_include = True
+            # Temporary fix for ROS Groovy and Hydro and the xacro include scope problem
+            if elt.tagName == 'include':
+                check_next = next_element(elt)
+                # check if there is a <uri> element within the <include> tag
+                if check_next.tagName == 'uri':
+                    # this is a correct gazebo element, so we can ignore it
+                    is_include = False
+                else:
+                    # throw a deprecated warning
+                    print(deprecated_include_msg, file=sys.stderr)
+
+        # Process current element depending on previous conditions
+        if is_include:
             filename = eval_text(elt.getAttribute('filename'), {})
             if not os.path.isabs(filename):
                 filename = os.path.join(base_dir, filename)


### PR DESCRIPTION
This is an unfortunate conflict because it might break some people's launch files, but xacro currently is not obeying its namespace as it says it does in its documentation. Gazebo's <gazebo> extension has its own <include> that is only used within its <gazebo> element, but Xacro is improperly trying to parse these as Xacro includes.

More details on Gazebo's issue tracker:
https://bitbucket.org/osrf/gazebo/issue/730/xacro-not-compatible-with-urdfs-sdfs

I'm only proposing we make this change in Hydro...

Reviewers
@jonbinney @jbohren  @nkoenig @hsu 
