### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,7 @@ install(PROGRAMS xacro.py DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(PROGRAMS scripts/xacro DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-## Add folders to be run by python nosetests
-catkin_add_nosetests(test)
+if(CATKIN_ENABLE_TESTING)
+  ## Add folders to be run by python nosetests
+  catkin_add_nosetests(test)
+endif()

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
 
   <author>Stuart Glaser</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <run_depend>roslaunch</run_depend>
 


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
