### PR TITLE
Add roslint target to xacro; two whitespace fixes so that it passes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,4 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(test)
 endif()
 
-file(GLOB ${PROJECT_NAME}_LINT_SRCS 
-  src/xacro/* scripts/* test/*.py)
-roslint_python(${${PROJECT_NAME}_LINT_SRCS})
+roslint_python()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(xacro)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED roslint)
 
 catkin_python_setup()
 
@@ -20,3 +20,7 @@ if(CATKIN_ENABLE_TESTING)
   ## Add folders to be run by python nosetests
   catkin_add_nosetests(test)
 endif()
+
+file(GLOB ${PROJECT_NAME}_LINT_SRCS 
+  src/xacro/* scripts/* test/*.py)
+roslint_python(${${PROJECT_NAME}_LINT_SRCS})

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
+  <build_depend>roslint</build_depend>
+
   <run_depend>roslaunch</run_depend>
 
   <test_depend>rostest</test_depend>

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -212,6 +212,7 @@ deprecated_include_msg = """DEPRECATED IN HYDRO:
 
 include_no_matches_msg = """Include tag filename spec \"{}\" matched no files."""
 
+
 ## @throws XacroException if a parsing error occurs with an included document
 def process_includes(doc, base_dir):
     namespaces = {}
@@ -253,7 +254,7 @@ def process_includes(doc, base_dir):
             else:
                 # Default behaviour
                 filenames = [filename_spec]
-            
+
             for filename in filenames:
                 global all_includes
                 all_includes.append(filename)


### PR DESCRIPTION
Not connected to the tests at this point—you have to manually `catkin_make roslint` or `catkin_make roslint_xacro` to see the linter output.
