### PR TITLE
fixup tests so they run, closes #34

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -274,7 +274,3 @@ class TestXacro(unittest.TestCase):
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
     <c />
 </robot>'''))
-
-if __name__ == '__main__':
-    import rostest
-    rostest.unitrun('xacro', 'test_xacro', TestXacro)


### PR DESCRIPTION
I don't think these tests have ever worked under catkin based on tests not running in hydro or indigo and xacro having only been catkinized in hydro. This commit lets us run all 16 test.
