### PR TITLE
stop test from failing the second time it is run

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -139,7 +139,7 @@ class TestXacro(unittest.TestCase):
         self.assertTrue(
             xml_matches(
                 quick_xacro('''<a><f v="$(find xacro)/test/test_xacro.py" /></a>'''),
-                '''<a><f v="''' + os.path.abspath(__file__) + '''" /></a>'''))
+                '''<a><f v="''' + os.path.abspath((__file__).replace(".pyc",".py")) + '''" /></a>'''))
 
     def test_substitution_args_arg(self):
         set_substitution_args_context(load_mappings(['sub_arg:=my_arg']))


### PR DESCRIPTION
This test references `__file__`, which, the first time it is run ends with a .py, however, the second time it is run, it will be a .pyc (since we no longer run test_xacro.py directly). This (somewhat hacky) fix will make sure we always use the .py filename.

If anyone has a better way to do this, I'm all ears. If not, I'll also open a hydro pull request once this is merged.
