### PR TITLE
add useful debugging information when parameters are not set

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -520,8 +520,8 @@ def eval_all(root, macros, symbols):
                         block = block.nextSibling
 
                 if params:
-                    raise XacroException("Some parameters were not set for macro %s" %
-                                         str(node.tagName))
+                    raise XacroException("Parameters [%s] were not set for macro %s" %
+                                         (",".join(params), str(node.tagName)))
                 eval_all(body, macros, scoped)
 
                 # Replaces the macro node with the expansion


### PR DESCRIPTION
This makes the error message when a parameter is not set a whole lot more useful for debugging what you are doing wrong. Before:

```
xacro.XacroException: Some parameters were not set for macro test_macro
```

After:

```
xacro.XacroException: Parameters [x,z] were not set for macro test_macro
```

This would close #33
