### PR TITLE
correct handling of floating point expressions in if/unless statements

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
     Xacro is an XML macro language. With xacro, you can construct shorter and more readable XML files by using macros that expand to larger XML expressions.
   </description>
 
-  <maintainer email="morgan@osrfoundation.org">Morgan "codebot" Quigley</maintainer>
+  <maintainer email="morgan@osrfoundation.org">Morgan 'codebot' Quigley</maintainer>
 
   <license>BSD</license>
 

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -249,24 +249,17 @@ class TestXacro(unittest.TestCase):
                           xacro.process_includes, doc, os.path.dirname(os.path.realpath(__file__)))
 
     def test_numeric_if_statement(self):
-        doc = parseString('''\
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:if value="${3*0}"/>
-  <xacro:if value="0"/>
-  <xacro:if value="1"/>
-</robot>''')
-        quick_xacro(doc)
         self.assertTrue(
             xml_matches(
                 quick_xacro('''\
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:if value="${3*0}">
+  <xacro:if value="${3*0.0}">
     <a />
   </xacro:if>
-  <xacro:if value="0">
+  <xacro:if value="false">
     <b />
   </xacro:if>
-  <xacro:if value="1">
+  <xacro:if value="${3*0.1}">
     <c />
   </xacro:if>
 </robot>'''),


### PR DESCRIPTION
So far if/unless cannot deal with floating point expressions that are not integer. There is no reason to not regard `1.3` has a `True` value. This commit fixes that: All floating point expression not evaluating to zero are handled as True. An appropriate test case is added as well.

The maintainer in `package.xml` shouldn't contain double quotes - changed.
