### PR TITLE
allow for recursive evaluation of properties

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -274,3 +274,17 @@ class TestXacro(unittest.TestCase):
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
     <c />
 </robot>'''))
+
+    def test_recursive_evaluation(self):
+        self.assertTrue(
+            xml_matches(
+                quick_xacro('''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="a" value="42"/>
+  <xacro:property name="a2" value="${2*a}"/>
+  <a doubled="${a2}"/>
+</robot>'''),
+                '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <a doubled="84"/>
+</robot>'''))

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -288,3 +288,12 @@ class TestXacro(unittest.TestCase):
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <a doubled="84"/>
 </robot>'''))
+
+    def test_recursive_definition(self):
+        self.assertRaises(xacro.XacroException,
+                          quick_xacro, '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="a" value="${a2}"/>
+  <xacro:property name="a2" value="${2*a}"/>
+  <a doubled="${a2}"/>
+</robot>''')


### PR DESCRIPTION
Recursive evaluation of properties, i.e. 
`<xacro:property name="a" value="42"/>
<xacro:property name="a2" value="${2*a}"/>`

should work. Currently, `${a2}` literally gives `${2*a}` instead of `84`.
This patch adds this feature, correctly catching recursive definitions. 
Proper functioning is checked by two new test cases.
