### PR TITLE
Allow xacro macros to have default values for parameters

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -504,6 +504,19 @@ def eval_all(root, macros, symbols):
                 body = macros[node.tagName].cloneNode(deep=True)
                 params = body.getAttribute('params').split()
 
+                defaultmap = {}
+                for param in params[:]:
+                    splitParam = param.split(':=')
+
+                    if len(splitParam) == 2:
+                        print("default detected")
+                        defaultmap[splitParam[0]] = splitParam[1]
+                        params.remove(param)
+                        params.append(splitParam[0])
+                        
+                    elif len(splitParam) != 1:
+                        raise XacroException("Invalid parameter defition")
+
                 # Expands the macro
                 scoped = Table(symbols)
                 for name, value in node.attributes.items():
@@ -526,6 +539,12 @@ def eval_all(root, macros, symbols):
                         params.remove(param)
                         scoped[param] = block
                         block = block.nextSibling
+
+                # Try to load defaults for any remaining parameters
+                for param in params[:]:
+                    if param[0] != '*' and param in defaultmap:
+                        scoped[param] = defaultmap[param]
+                        params.remove(param)
 
                 if params:
                     raise XacroException("Parameters [%s] were not set for macro %s" %

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -504,18 +504,18 @@ def eval_all(root, macros, symbols):
                 body = macros[node.tagName].cloneNode(deep=True)
                 params = body.getAttribute('params').split()
 
+                # Parse default values for any parameters
                 defaultmap = {}
                 for param in params[:]:
                     splitParam = param.split(':=')
 
                     if len(splitParam) == 2:
-                        print("default detected")
                         defaultmap[splitParam[0]] = splitParam[1]
                         params.remove(param)
                         params.append(splitParam[0])
                         
                     elif len(splitParam) != 1:
-                        raise XacroException("Invalid parameter defition")
+                        raise XacroException("Invalid parameter definition")
 
                 # Expands the macro
                 scoped = Table(symbols)
@@ -540,7 +540,7 @@ def eval_all(root, macros, symbols):
                         scoped[param] = block
                         block = block.nextSibling
 
-                # Try to load defaults for any remaining parameters
+                # Try to load defaults for any remaining non-block parameters
                 for param in params[:]:
                     if param[0] != '*' and param in defaultmap:
                         scoped[param] = defaultmap[param]

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -403,3 +403,73 @@ class TestXacro(unittest.TestCase):
   <tag badness="${1/x}"/>
 </robot>''')
 
+    def test_default_param(self):
+        self.assertTrue(
+            xml_matches(
+                quick_xacro('''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="fixed_link" params="parent_link:=base_link child_link *joint_pose">
+    <link name="${child_link}"/>
+    <joint name="${child_link}_joint" type="fixed">
+      <xacro:insert_block name="joint_pose" />
+      <parent link="${parent_link}"/>
+      <child link="${child_link}" />
+    </joint>
+  </xacro:macro>
+  <xacro:fixed_link child_link="foo">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:fixed_link >
+</robot>'''), 
+                '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <link name="foo"/>
+  <joint name="foo_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="foo"/>
+  </joint>
+</robot>'''))
+
+    def test_default_param_override(self):
+        self.assertTrue(
+            xml_matches(
+                quick_xacro('''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="fixed_link" params="parent_link:=base_link child_link *joint_pose">
+    <link name="${child_link}"/>
+    <joint name="${child_link}_joint" type="fixed">
+      <xacro:insert_block name="joint_pose" />
+      <parent link="${parent_link}"/>
+      <child link="${child_link}" />
+    </joint>
+  </xacro:macro>
+  <xacro:fixed_link child_link="foo" parent_link="bar">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:fixed_link >
+</robot>'''), 
+                '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <link name="foo"/>
+  <joint name="foo_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="bar"/>
+    <child link="foo"/>
+  </joint>
+</robot>'''))
+
+    def test_param_missing(self):
+        self.assertRaises(xacro.XacroException,
+                          quick_xacro, '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="fixed_link" params="parent_link child_link *joint_pose">
+    <link name="${child_link}"/>
+    <joint name="${child_link}_joint" type="fixed">
+      <xacro:insert_block name="joint_pose" />
+      <parent link="${parent_link}"/>
+      <child link="${child_link}" />
+    </joint>
+  </xacro:macro>
+  <xacro:fixed_link child_link="foo">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:fixed_link >
+</robot>''')


### PR DESCRIPTION
Allow xacro macros to have parameters defined in the style:

`<xacro:macro name="test_macro" params="param1:=default_value param2 *block_param">`

and then allow the usage:

`<xacro:test_macro param2="test2">`

Where param1 receives default_value if not specified in the macro usage.
