### PR TITLE
Include CATKIN_ENV params at build time.

### DIFF
--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -18,7 +18,7 @@ macro(xacro_add_xacro_file input output)
   separate_arguments(_xacro_deps_result)
 
   add_custom_command(OUTPUT ${output}
-    COMMAND ${_xacro_py}
+    COMMAND ${CATKIN_ENV} ${_xacro_py}
     ARGS ${input} -o ${output}
     DEPENDS ${input} ${_xacro_deps_result})
 endmacro(xacro_add_xacro_file)


### PR DESCRIPTION
`CATKIN_ENV` param is not included at build time and causes the `$(find pkg)`
macro to fail if the package is local to the build space and not found in `ROS_PACKAGE_PATH`

`CATKIN_ENV` param has been added to the `COMMAND` call in process execution
makefile argument.
