### PR TITLE
various improvements to xacro

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -39,6 +39,7 @@ import re
 import string
 import sys
 import xml
+import ast
 
 from xml.dom.minidom import parse
 
@@ -129,9 +130,7 @@ class Table:
         if isinstance(value, basestring):
             try:
                 # try to evaluate as literal, e.g. number, boolean, etc.
-                value = eval(value)
-                # TODO: store integers as float to maintain backward compatibility?
-                # if isinstance(value, int): value=float(value)
+                value = ast.literal_eval(value)
             except:
                 # otherwise simply store as original string for later (re)evaluation
                 pass
@@ -557,11 +556,14 @@ def eval_all(root, macros={}, symbols=Table()):
                 node = None
 
             elif node.tagName in ['if', 'xacro:if', 'unless', 'xacro:unless']:
-                value = str(eval_text(node.getAttribute('value'), symbols))
+                value = eval_text(node.getAttribute('value'), symbols)
                 try: 
                     # try to interpret value as boolean
-                    # dict explicitly enables 'true' and 'false'
-                    keep = bool(eval(value, dict(true=True, false=False)))
+                    if isinstance(value, basestring): 
+                        if   value == "true": keep = True
+                        elif value == "false": keep = False
+                        else: keep = ast.literal_eval(value)
+                    else: keep = bool(value)
                 except:
                     print ("if failure", value, type(value))
                     raise

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -235,9 +235,9 @@ def is_include(elt):
             print(deprecated_include_msg, file=sys.stderr)
     return True
 
-def process_include(elt):
+def process_include(elt, symbols):
     namespaces = {}
-    filename_spec = eval_text(elt.getAttribute('filename'), {})
+    filename_spec = eval_text(elt.getAttribute('filename'), symbols)
     if not os.path.isabs(filename_spec):
         filename_spec = os.path.join(basedir, filename_spec)
 
@@ -288,7 +288,7 @@ def process_includes(doc, dir=None):
     elt = next_element(previous)
     while elt:
         if is_include(elt):
-            process_include(elt)
+            process_include(elt, {})
         else:
             previous = elt
 
@@ -530,7 +530,7 @@ def eval_all(root, macros={}, symbols=Table()):
     while node:
         if node.nodeType == xml.dom.Node.ELEMENT_NODE:
             if is_include(node):
-                process_include(node)
+                process_include(node, symbols)
                 node = next_node(previous)
                 continue
 

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -389,7 +389,9 @@ def grab_properties(doc, table=Table()):
 def eval_text(text, symbols):
     def handle_expr(s):
         try:
-            return eval(s, {}, symbols)
+            # taking simple security measures to forbid access to __builtins__
+            # for discussion, see: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+            return eval(s, {'__builtins__':{}}, symbols)
         except NameError as e:
             raise XacroException("%s evaluating expression '%s'" % (str(e), s))
         except Exception as e:

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -145,6 +145,28 @@ class TestMatchXML(unittest.TestCase):
 
 class TestXacro(unittest.TestCase):
 
+    def test_dynamic_macro_names(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo"><a>foo</a></xacro:macro>
+  <xacro:macro name="bar"><b>bar</b></xacro:macro>
+  <xacro:property name="var" value="%s"/>
+  <xacro:call macro="${var}"/></a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">%s</a>'''
+        self.assertTrue(xml_matches(quick_xacro(src % "foo"), res % "<a>foo</a>"))
+        self.assertTrue(xml_matches(quick_xacro(src % "bar"), res % "<b>bar</b>"))
+
+    def test_dynamic_macro_name_clash(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo"><a name="foo"/></xacro:macro>
+  <xacro:macro name="call"><a name="bar"/></xacro:macro>
+  <xacro:call/></a>'''
+        # for now we only issue a deprecated warning and expect the old behaviour
+        # resolving macro "call"
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><a name="bar"/></a>'''
+        # new behaviour would be to resolve to foo of course
+        # res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><a name="foo"/></a>'''
+        self.assertTrue(xml_matches(quick_xacro(src), res))
+
     def test_DEPRECATED_should_replace_before_macroexpand(self):
         self.assertTrue(
             xml_matches(

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -440,6 +440,29 @@ class TestXacro(unittest.TestCase):
 </a>'''),
 '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"/>'''))
 
+    def test_equality_expression_in_if_statement(self):
+        self.assertTrue(
+            xml_matches(quick_xacro('''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="var" value="useit"/>
+  <xacro:if value="${var == 'useit'}"><foo>bar</foo></xacro:if>
+  <xacro:if value="${'use' in var}"><bar>foo</bar></xacro:if>
+</a>'''),
+'''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<foo>bar</foo>
+<bar>foo</bar>
+</a>'''))
+
+    def test_math_expressions(self):
+        self.assertTrue(
+            xml_matches(quick_xacro('''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <foo function="${1. + sin(pi)}"/>
+</a>'''),
+'''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <foo function="1.0"/>
+</a>'''))
+
     def test_consider_non_elements_if(self):
         self.assertTrue(
             xml_matches(quick_xacro('''

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -484,6 +484,20 @@ class TestXacro(unittest.TestCase):
   <a doubled="84"/>
 </robot>'''))
 
+    def test_recursive_evaluation_wrong_order(self):
+        self.assertTrue(
+            xml_matches(
+                quick_xacro('''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="a2" value="${2*a}"/>
+  <xacro:property name="a" value="42"/>
+  <a doubled="${a2}"/>
+</robot>'''),
+                '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <a doubled="84"/>
+</robot>'''))
+
     def test_recursive_definition(self):
         self.assertRaises(xacro.XacroException,
                           quick_xacro, '''\

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -360,6 +360,21 @@ class TestXacro(unittest.TestCase):
         self.assertRaises(xacro.XacroException,
                           xacro.process_includes, doc, os.path.dirname(os.path.realpath(__file__)))
 
+    def test_include_from_variable(self):
+        doc = ('''<a xmlns:xacro="http://www.ros.org/xacro">
+        <xacro:property name="file" value="include1.xml"/>
+        <xacro:include filename="${file}" /></a>''')
+        self.assertTrue(
+            xml_matches(quick_xacro(doc, inorder=True),
+                        '''<a xmlns:xacro="http://www.ros.org/xacro"><foo /><bar /></a>'''))
+
+    def test_include_lazy(self):
+        doc = ('''<a xmlns:xacro="http://www.ros.org/xacro">
+        <xacro:if value="false"><xacro:include filename="non-existent"/></xacro:if></a>''')
+        self.assertTrue(
+            xml_matches(quick_xacro(doc, inorder=True),
+                        '''<a xmlns:xacro="http://www.ros.org/xacro"/>'''))
+
     def test_boolean_if_statement(self):
         self.assertTrue(
             xml_matches(

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -453,6 +453,17 @@ class TestXacro(unittest.TestCase):
 <bar>foo</bar>
 </a>'''))
 
+    def test_no_evaluation(self):
+        self.assertTrue(
+            xml_matches(quick_xacro('''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <property name="xyz" value="5 -2"/>
+  <foo>${xyz}</foo>
+</a>'''),
+'''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <foo>5 -2</foo>
+</a>'''))
+
     def test_math_expressions(self):
         self.assertTrue(
             xml_matches(quick_xacro('''


### PR DESCRIPTION
Dear maintainer,

this isn't a classical pull request, but rather a <b>pull proposal</b>. It comprises:
- fixup of unittests / `xml_matches()`, handling of non-element nodes in `<include>`, `<if>`, `<macro>` as  indicated in previous [pull request #48](https://github.com/ros/xacro/pull/48)
- dynamic macro names: `<xacro:call macro="${variable}"/>`
- XML processing in read-order to avoid issues with multiply defined macros or properties
- python-based evaluation of expressions: utilizing `eval()` instead of the hand-coded parser

All changes build on top of each other to some extend. They have associated branches in [our xacro fork](https://github.com/ubi-agni/xacro/tree/agni). A more detailed motivation for the individual changes can found in the [README](https://github.com/ubi-agni/xacro/tree/agni#xacro)

I'm aware of the fact, that these changes heavily modify the original code. To get an overview of all changes you should follow the individual commits, which I carefully packaged into meaningful and easily comprehensible steps. Of course, I'm open for questions and discussion as well ;-)

I'm also aware of the fact, that my changes will have some impact on existing xacro files out there. I see namely three changes xacro users need to take care of:
- Ordered processing will break stuff, that relied on the specific manner xacro was processing includes, macros and properties - utilizing the latest definition only for evaluation. However, even the rather complex `pr2 example` doesn't rely on this fact, but successfully compiles in both modes.
  Because I'm aware of this fact, I decided to enable the ordered-processing optionally only, with the command line option --inorder
- copying any type of top-level XML nodes from `<include>`, `<if>`, `<macro>` will also change the previous behaviour. This will be irrelevant however for urdf, because urdf only considers element nodes anyway.
- Finally, the python-based evaluation will modify the handling of integer division: While the old parser silently switches to floats when doing integer division, python eval - as any other programming language - distinguishes between integer and float division. From my point of view, this will be the most important change to take care of by end users.

By the way, why did you opted for an own, hand-written expression parser instead of using python's capabilities? I don't see any benefit for this.

Having said all this, I would be happy if you are interested in some of these contributions and would like to consider them for the next or over-next ROS release.

Kind regards, Robert
