### PR TITLE
fixed bookkeeping in lazy evaluation

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -557,6 +557,22 @@ class TestXacro(unittest.TestCase):
   <answer product="6"/>
 </robot>'''))
 
+    def test_multiple_definition_and_evaluation(self):
+        self.assertTrue(
+            xml_matches(
+                quick_xacro('''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="a" value="42"/>
+  <xacro:property name="b" value="${a}"/>
+  <xacro:property name="b" value="${-a}"/>
+  <xacro:property name="b" value="${a}"/>
+  <answer b="${b} ${b} ${b}"/>
+</robot>'''),
+                '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <answer b="42 42 42"/>
+</robot>'''))
+
     def test_transitive_evaluation(self):
         self.assertTrue(
             xml_matches(


### PR DESCRIPTION
Dear Morgan,

I observed a minor bug in the python eval code. When a property was (re)defined several times _and_ used/evaluated several times, I didn't correctly noticed, that is was already evaluated, causing an exception in eval() when trying to evaluate the non-text value again - appropriate test case added. I fixed this by using a set for self.unevaluated (instead of a list), which keeps track of unevaluated variables. 
Additionally, I moved the resolving code into an own function _resolve_ to increase readability.

Now I'm working towards improving the processing speed. Profiling xacro on large files (which take up to 30s on our system) reveals, that the major bottlenecks are the QuickLexer and xml.minidom.insertBefore(). I already fixed the former (I will issue another pull request for this). 
Regarding the latter, do you have any objections to replace xml.minidom by e.g. lxml.etree?
