### PR TITLE
fixed xacro's cmake macros

### DIFF
--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -39,3 +39,8 @@ macro(xacro_add_xacro_file input output)
     COMMAND ${CATKIN_ENV} ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
     DEPENDS ${input_abs} ${_xacro_deps_result})
 endmacro(xacro_add_xacro_file)
+
+macro(xacro_add_target input output)
+  xacro_add_xacro_file(${input} ${output} ${ARGN})
+  add_custom_target(_auto_gen_${output} ALL DEPENDS ${output})
+endmacro(xacro_add_target)

--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -23,16 +23,15 @@ macro(xacro_add_xacro_file input output)
 
   # Call out to xacro to get dependencies
   execute_process(COMMAND ${_xacro_py} --deps ${input_abs} ${_XACRO_REMAP}
-    ERROR_VARIABLE _xacro_err_ignore
+    ERROR_VARIABLE _xacro_err
     OUTPUT_VARIABLE _xacro_deps_result
     OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(_xacro_err)
+    message(WARNING "failed to determine deps for: ${input}
+${_xacro_err}")
+  endif(_xacro_err)
 
   separate_arguments(_xacro_deps_result)
-
-  # stringify _XACRO_REMAP: turning list into a space-separated string
-  foreach(remap ${_XACRO_REMAP})
-    set(_xacro_remap_args "${_xacro_remap_args} ${remap}")
-  endforeach(remap)
 
   add_custom_command(OUTPUT ${output}
     COMMAND echo ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}

--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -29,8 +29,13 @@ macro(xacro_add_xacro_file input output)
 
   separate_arguments(_xacro_deps_result)
 
+  # stringify _XACRO_REMAP: turning list into a space-separated string
+  foreach(remap ${_XACRO_REMAP})
+    set(_xacro_remap_args "${_xacro_remap_args} ${remap}")
+  endforeach(remap)
+
   add_custom_command(OUTPUT ${output}
-    COMMAND echo "running XACRO: ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}"
+    COMMAND echo ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
     COMMAND ${CATKIN_ENV} ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
     DEPENDS ${input_abs} ${_xacro_deps_result})
 endmacro(xacro_add_xacro_file)


### PR DESCRIPTION
- correctly handle multiple remapping args
- added convenience cmake-macro `xacro_add_target(input output INORDER REMAP ...)`
