### PR TITLE
cmake macro improvements

### DIFF
--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -23,14 +23,18 @@ macro(xacro_add_xacro_file input output)
 
   # Call out to xacro to get dependencies
   execute_process(COMMAND ${_xacro_py} --deps ${input_abs} ${_XACRO_REMAP}
-    ERROR_VARIABLE _xacro_err_ignore
+    ERROR_VARIABLE _xacro_err
     OUTPUT_VARIABLE _xacro_deps_result
     OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(_xacro_err)
+    message(WARNING "failed to determine deps for: ${input}
+${_xacro_err}")
+  endif(_xacro_err)
 
   separate_arguments(_xacro_deps_result)
 
   add_custom_command(OUTPUT ${output}
-    COMMAND echo "running XACRO: ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}"
+    COMMAND echo ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
     COMMAND ${CATKIN_ENV} ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
     DEPENDS ${input_abs} ${_xacro_deps_result})
 endmacro(xacro_add_xacro_file)

--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -22,6 +22,7 @@ macro(xacro_add_xacro_file input output)
   get_filename_component(input_abs ${input} ABSOLUTE)
 
   # Call out to xacro to get dependencies
+  message(STATUS "xacro: determining deps for: " ${input} " ...")
   execute_process(COMMAND ${_xacro_py} --deps ${input_abs} ${_XACRO_REMAP}
     ERROR_VARIABLE _xacro_err
     OUTPUT_VARIABLE _xacro_deps_result

--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -39,3 +39,11 @@ ${_xacro_err}")
     COMMAND ${CATKIN_ENV} ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
     DEPENDS ${input_abs} ${_xacro_deps_result})
 endmacro(xacro_add_xacro_file)
+
+macro(xacro_add_target input output)
+  xacro_add_xacro_file(${input} ${output} ${ARGN})
+  # create target name from ${output} (which might contain directory separators)
+  file(TO_CMAKE_PATH ${output} _target_name)
+  string(REPLACE "/" "_" _target_name _auto_gen_${_target_name})
+  add_custom_target(${_target_name} ALL DEPENDS ${output})
+endmacro(xacro_add_target)

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -700,6 +700,15 @@ def process_doc(doc,
     substitution_args_context['arg'] = {}
 
 
+def open_output(output_filename):
+    if output_filename is None:
+        return sys.stdout
+    else:
+        dir_name = os.path.dirname(output_filename)
+        if dir_name and not os.path.isdir(dir_name): os.makedirs(dir_name)
+        return open(output_filename, 'w')
+
+
 def main():
     opts, input_file = process_cli_args(sys.argv[1:])
     f = open(input_file)
@@ -716,7 +725,7 @@ def main():
         f.close()
 
     process_doc(doc, **vars(opts))
-    out = open(opts.output, 'w') if opts.output else sys.stdout
+    out = open_output(opts.output)
 
     if opts.just_deps:
         out.write(" ".join(all_includes))


### PR DESCRIPTION
Meanwhile I have some improvements for xacro's cmake macro.

And there is a bugfix for the `-o option`: Running `xacro -o new_dir/output input` failed when `new_dir` wasn't there before. I guess this wasn't by purpose, was it?

Adding an appropriate regression test is on my todo list...
