### PR TITLE
improved xacro's cmake macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ install(PROGRAMS xacro.py DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 if(CATKIN_ENABLE_TESTING)
   ## Add folders to be run by python nosetests
   catkin_add_nosetests(test)
+  ## add tests for xacro's cmake functions
+  add_subdirectory(test)
 endif()
 
 roslint_python()

--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -38,6 +38,7 @@ add_custom_target(_xacro_generated_to_devel_space_ ALL)
 function(xacro_add_xacro_file input)
   # parse arguments
   set(options INORDER)
+  set(oneValueArgs OUTPUT)
   set(multiValueArgs REMAP)
   cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -118,7 +119,7 @@ function(xacro_install target)
 
   ## rule to create target dir
   file(TO_CMAKE_PATH ${CATKIN_PACKAGE_SHARE_DESTINATION}/${_XACRO_DESTINATION} dest)
-  set(TARGET_DIR ${CATKIN_DEVEL_PREFIX}/${dest})
+  file(TO_CMAKE_PATH ${CATKIN_DEVEL_PREFIX}/${dest} TARGET_DIR)
   add_custom_command(OUTPUT ${TARGET_DIR}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${TARGET_DIR}
     COMMENT "creating dir ${TARGET_DIR}")
@@ -133,7 +134,7 @@ function(xacro_install target)
     add_custom_command(OUTPUT ${tgt}
       COMMAND ${CMAKE_COMMAND} -E copy ${output} ${tgt}
       DEPENDS ${TARGET_DIR} ${output}
-      COMMENT "Installing: ${tgt}"
+      COMMENT "Copying to devel space: ${tgt}"
       )
   endforeach()
 

--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -1,29 +1,91 @@
 @[if DEVELSPACE]@
 set(_xacro_py
   @(CMAKE_CURRENT_SOURCE_DIR)/scripts/xacro
-)
+  )
 @[else]@
 set(_xacro_py
   ${xacro_DIR}/../../../@(CATKIN_PACKAGE_BIN_DESTINATION)/xacro
-)
+  )
 @[end if]@
 
-macro(xacro_add_xacro_file input output)
-  set(options OPTIONAL INORDER)
+add_custom_target(_xacro_generated_to_devel_space_ ALL)
+
+
+## xacro_add_xacro_file(<input> [<output>] [INORDER] [REMAP <arg> <arg> ...]
+##                      [OUTPUT <variable>])
+##
+## Creates a command run xacro on <input> like so:
+## xacro [--inorder] -o <output> <input> [<remap args>]
+##
+## If <output> was not specified, it is determined from <input> removing the suffix .xacro
+## The absolute output file name is returned in variable <output>, which defaults to
+## XACRO_OUTPUT_FILE.
+##
+## In order to actually build and install, you need to provide a custom target:
+## foreach(xacro_file ${MY_XACRO_FILES})
+##   xacro_add_xacro_file(${xacro_file} INORDER REMAP bar:=foo foo:=bar)
+##   list(APPEND xacro_outputs ${XACRO_OUTPUT_FILE})
+## endforeach()
+## add_custom_target(xacro_target ALL DEPENDS ${xacro_outputs})
+## xacro_install(xacro_target ${xacro_outputs} DESTINATION xml)
+##
+## Be aware, that xacro_install() is required to install into both, install and devel space.
+## Normal install() only installs into install space!
+##
+## For conveniency, you might want to use xacro_add_files(), which does the same:
+## xacro_add_files(${MY_XACRO_FILES} INORDER REMAP bar:=foo foo:=bar
+##                 TARGET xacro_target INSTALL DESTINATION xml)
+function(xacro_add_xacro_file input)
+  # parse arguments
+  set(options INORDER)
   set(multiValueArgs REMAP)
   cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  ## process arguments
+  # retrieve output file name
+  if(_XACRO_UNPARSED_ARGUMENTS)
+    # output file explicitly specified
+    list(GET _XACRO_UNPARSED_ARGUMENTS 0 output)
+    list(REMOVE_AT _XACRO_UNPARSED_ARGUMENTS 0)
+    # any remaining unparsed args?
+    if(_XACRO_UNPARSED_ARGUMENTS)
+      message(WARNING "unknown arguments: ${_XACRO_UNPARSED_ARGUMENTS}")
+    endif(_XACRO_UNPARSED_ARGUMENTS)
+  else()
+    # implicitly determine output file from input
+    if(${input} MATCHES "(.*)[.]xacro$")
+      set(output ${CMAKE_MATCH_1})
+    else()
+      message(FATAL_ERROR "no <output> specified for: " ${input})
+    endif()
+  endif()
+  # message(STATUS "output: ${output}")
+
+  # transform _XACRO_INORDER's BOOL value
   if(_XACRO_INORDER)
     set(_XACRO_INORDER "--inorder")
   else()
     unset(_XACRO_INORDER)
   endif()
 
-  # create absolute input filename (if not yet absolute)
-  get_filename_component(input_abs ${input} ABSOLUTE)
+  ## determine absolute output target location
+  if(IS_ABSOLUTE ${output})
+    set(abs_output ${output})
+  else()
+    set(abs_output ${CMAKE_CURRENT_BINARY_DIR}/${output})
+  endif()
+  # message(STATUS "abs_output: ${abs_output}")
 
-  # Call out to xacro to get dependencies
+  ## export abs_output to parent scope in variable ${_XACRO_OUTPUT}
+  if(NOT _XACRO_OUTPUT)
+    set(_XACRO_OUTPUT XACRO_OUTPUT_FILE)
+  endif()
+  set(${_XACRO_OUTPUT} ${abs_output} PARENT_SCOPE)
+
+  ## Call out to xacro to determine dependencies
   message(STATUS "xacro: determining deps for: " ${input} " ...")
-  execute_process(COMMAND ${_xacro_py} --deps ${input_abs} ${_XACRO_REMAP}
+  execute_process(COMMAND ${_xacro_py} --deps ${input} ${_XACRO_REMAP}
+    WORKING_DIRECTORY $(CMAKE_CURRENT_SOURCE_DIR)
     ERROR_VARIABLE _xacro_err
     OUTPUT_VARIABLE _xacro_deps_result
     OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -34,16 +96,103 @@ ${_xacro_err}")
 
   separate_arguments(_xacro_deps_result)
 
+  ## command to actually call xacro
   add_custom_command(OUTPUT ${output}
-    COMMAND echo ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
-    COMMAND ${CATKIN_ENV} ${_xacro_py} ${_XACRO_INORDER} -o ${output} ${input_abs} ${_XACRO_REMAP}
-    DEPENDS ${input_abs} ${_xacro_deps_result})
-endmacro(xacro_add_xacro_file)
+    COMMAND ${CATKIN_ENV} ${_xacro_py} ${_XACRO_INORDER} -o ${abs_output} ${input} ${_XACRO_REMAP}
+    DEPENDS ${input} ${_xacro_deps_result}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "xacro: generating ${output} from ${input}"
+    )
+endfunction(xacro_add_xacro_file)
 
-macro(xacro_add_target input output)
-  xacro_add_xacro_file(${input} ${output} ${ARGN})
-  # create target name from ${output} (which might contain directory separators)
-  file(TO_CMAKE_PATH ${output} _target_name)
-  string(REPLACE "/" "_" _target_name _auto_gen_${_target_name})
-  add_custom_target(${_target_name} ALL DEPENDS ${output})
-endmacro(xacro_add_target)
+
+## xacro_install(<target> <output> [<output> ...] DESTINATION <path>)
+##
+## installs xacro-generated files both to devel and input space
+## into ${CATKIN_PACKAGE_SHARE_DESTINATION}/<path>
+function(xacro_install target)
+  # parse arguments
+  set(oneValueArgs DESTINATION)
+  cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(outputs ${_XACRO_UNPARSED_ARGUMENTS})
+
+  ## rule to create target dir
+  file(TO_CMAKE_PATH ${CATKIN_PACKAGE_SHARE_DESTINATION}/${_XACRO_DESTINATION} dest)
+  set(TARGET_DIR ${CATKIN_DEVEL_PREFIX}/${dest})
+  add_custom_command(OUTPUT ${TARGET_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${TARGET_DIR}
+    COMMENT "creating dir ${TARGET_DIR}")
+
+  ## process list of outputs
+  foreach(output ${outputs})
+    get_filename_component(tgt ${output} NAME)
+    file(TO_CMAKE_PATH ${TARGET_DIR}/${tgt} tgt)
+    list(APPEND tgts ${tgt})
+
+    # rule to create devel space tgt
+    add_custom_command(OUTPUT ${tgt}
+      COMMAND ${CMAKE_COMMAND} -E copy ${output} ${tgt}
+      DEPENDS ${TARGET_DIR} ${output}
+      COMMENT "Installing: ${tgt}"
+      )
+  endforeach()
+
+  ## rule to create devel space tgts
+  add_custom_target(${target}_to_devel_space_ DEPENDS ${tgts})
+  # add to main target _xacro_generated_to_devel_space_
+  add_dependencies(_xacro_generated_to_devel_space_ ${target}_to_devel_space_)
+
+
+  ## normal install
+  install(FILES ${outputs} DESTINATION ${dest})
+endfunction(xacro_install)
+
+
+## xacro_add_files(<file> [<file> ...] [INORDER] [REMAP <arg> <arg> ...]
+##                 [TARGET <target>] [INSTALL [DESTINATION <path>]])
+##
+## create make <target> to generate xacro files
+## and optionally install to ${CATKIN_PACKAGE_SHARE_DESTINATION}/<path>
+## in devel and install space.
+function(xacro_add_files)
+  # parse arguments
+  set(options INORDER INSTALL)
+  set(oneValueArgs OUTPUT TARGET DESTINATION)
+  set(multiValueArgs REMAP)
+  cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  ## process arguments
+  # transform _XACRO_INORDER's BOOL value
+  if(_XACRO_INORDER)
+    set(_XACRO_INORDER "INORDER")
+  else()
+    unset(_XACRO_INORDER)
+  endif()
+
+  # prepare REMAP args (prepending REMAP)
+  if(_XACRO_REMAP)
+    set(_XACRO_REMAP REMAP ${_XACRO_REMAP})
+  endif()
+
+  # have INSTALL option, but no TARGET: fallback to default target
+  if(_XACRO_INSTALL AND NOT _XACRO_TARGET)
+    # message(STATUS "xacro: no TARGET specified, using default")
+    set(_XACRO_TARGET _xacro_auto_generate)
+  endif()
+
+  foreach(input ${_XACRO_UNPARSED_ARGUMENTS})
+    # call to main function
+    xacro_add_xacro_file(${input} ${_XACRO_OUTPUT} ${_XACRO_INORDER} ${_XACRO_REMAP})
+    list(APPEND outputs ${XACRO_OUTPUT_FILE})
+  endforeach()
+
+  if(outputs)
+    # link to target
+    add_custom_target(${_XACRO_TARGET} ALL DEPENDS ${outputs})
+
+    # install?
+    if(_XACRO_INSTALL)
+      xacro_install(${_XACRO_TARGET} ${outputs} DESTINATION ${_XACRO_DESTINATION})
+    endif(_XACRO_INSTALL)
+  endif()
+endfunction(xacro_add_files)

--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -8,7 +8,7 @@ set(_xacro_py
   )
 @[end if]@
 
-add_custom_target(_xacro_generated_to_devel_space_ ALL)
+add_custom_target(${PROJECT_NAME}_xacro_generated_to_devel_space_ ALL)
 
 
 ## xacro_add_xacro_file(<input> [<output>] [INORDER] [REMAP <arg> <arg> ...]
@@ -139,9 +139,10 @@ function(xacro_install target)
   endforeach()
 
   ## rule to create devel space tgts
-  add_custom_target(${target}_to_devel_space_ DEPENDS ${tgts})
+  add_custom_target(${PROJECT_NAME}_${target}_to_devel_space_ DEPENDS ${tgts})
   # add to main target _xacro_generated_to_devel_space_
-  add_dependencies(_xacro_generated_to_devel_space_ ${target}_to_devel_space_)
+  add_dependencies(${PROJECT_NAME}_xacro_generated_to_devel_space_ 
+                   ${PROJECT_NAME}_${target}_to_devel_space_)
 
 
   ## normal install
@@ -189,7 +190,7 @@ function(xacro_add_files)
 
   if(outputs)
     # link to target
-    add_custom_target(${_XACRO_TARGET} ALL DEPENDS ${outputs})
+    add_custom_target(${PROJECT_NAME}_${_XACRO_TARGET} ALL DEPENDS ${outputs})
 
     # install?
     if(_XACRO_INSTALL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_test(NAME xacro_cmake
+  # run test-cmake.sh for subdir test-xacro-cmake
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-cmake.sh ${CMAKE_CURRENT_SOURCE_DIR}/test-xacro-cmake
+  )

--- a/test/test-cmake.sh
+++ b/test/test-cmake.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+### script for testing cmake build chain ###
+#
+# In order to check correctness of cmake macros defined in
+# cmake/xacro-extras.cmake.em, this script checks for
+# successfully running the cmake toolchain, i.e. cmake, make, make install.
+# Providing different test directories as first argument, this script can check
+# different CMakeLists.txt.
+#
+# Even better would be a unittest framework within cmake, e.g.
+# http://stackoverflow.com/questions/29818725/cmake-how-to-unit-test-your-own-cmake-script-macros-functions
+
+# Is argument $1 a valid cmake source directory?
+test -d $1 || exit 2
+test -r $1/CMakeLists.txt || exit 2
+
+dir=`basename $1`
+
+# redirect stdout and stderr to $dir.log
+exec &> $dir.log 2>&1
+
+# cleanup our build dir
+rm -rf $dir
+mkdir $dir
+cd $dir
+
+# load catkin environent
+build_env=../../build_env.sh
+
+echo "*** running cmake ***"
+${build_env} cmake -DCATKIN_DEVEL_PREFIX=devel -DCMAKE_INSTALL_PREFIX=install $1 || exit $?
+
+echo
+echo "*** running make ***"
+${build_env} make || exit $?
+
+echo
+echo "*** running make install ***"
+${build_env} make || exit $?

--- a/test/test-xacro-cmake/CMakeLists.txt
+++ b/test/test-xacro-cmake/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(xacro-test)
+
+include(CMakeParseArguments)
+find_package(xacro REQUIRED)
+
+## manual usage of eval
+xacro_add_xacro_file(../include1.xml manual1.xml INORDER)
+list(APPEND xacro_outputs ${XACRO_OUTPUT_FILE})
+
+xacro_add_xacro_file(../include2.xml manual2.xml INORDER OUTPUT MY_OUTPUT_VAR)
+list(APPEND xacro_outputs ${MY_OUTPUT_VAR})
+
+add_custom_target(xacro_target ALL DEPENDS ${xacro_outputs})
+xacro_install(xacro_target ${xacro_outputs} DESTINATION xml)
+
+## convienency function
+xacro_add_files(TARGET xacro test.xacro REMAP bar:=foo foo:=bar INSTALL)

--- a/test/test-xacro-cmake/test.xacro
+++ b/test/test-xacro-cmake/test.xacro
@@ -1,0 +1,1 @@
+<a foo="$(arg foo)" bar="$(arg bar)"/>


### PR DESCRIPTION
- replaced macro with function: have local variable namespace in function!
- xacro_add_xacro_file() automatically determines output file from input (removing .xacro suffix).
  If that fails, a fatal error is raised. The created output file is returned to caller.
- added xacro_install() to allow installation into both, devel and install space.
- replaced conveniency macro xacro_add_target() with function xacro_add_files()
- added docs of functions to source file
