### PR TITLE
added missing print_location_msg() for file that actually failed parsing

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -342,8 +342,8 @@ def process_includes(doc, filename):
                     # recursively process includes
                     process_includes(included, included_filename)
                     # embed included doc before elt
-
                     process_include(elt, included)
+
             except Exception as e:
                 print_location_msg(e, filename)
                 raise
@@ -508,6 +508,7 @@ def eval_all(root, filename, macros={}, symbols=Table()):
                         eval_all(included.documentElement, included_filename, macros, symbols)
                         # embed included doc before node
                         process_include(node, included)
+
                 except Exception as e:
                     print_location_msg(e, filename)
                     raise
@@ -698,6 +699,10 @@ def parse(inp, filename=None):
         elif isinstance(inp, file):
             return xml.dom.minidom.parse(inp)
         return inp
+
+    except Exception as e:
+        print_location_msg(e, filename)
+        raise
 
     finally:
         if f: f.close()


### PR DESCRIPTION
This is a fixup of #75: The actual file that failed parsing, wasn't printed on console.
