### PR TITLE
improved error reporting

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -351,7 +351,7 @@ def get_include_files(elt, parent_filename, symbols):
         # Globbing behaviour
         filenames = sorted(glob.glob(filename_spec))
         if len(filenames) == 0:
-            print(include_no_matches_msg.format(filename_spec), file=sys.stderr)
+            warning(include_no_matches_msg.format(filename_spec))
     else:
         # Default behaviour
         filenames = [filename_spec]
@@ -446,8 +446,8 @@ def grab_property(elt, table):
 
     bad = string.whitespace + "${}"
     if any(ch in name for ch in bad):
-        sys.stderr.write('Property names may not have whitespace, ' +
-                         '"{", "}", or "$" : "' + name + '"')
+        warning('Property names may not have whitespace, ' +
+                '"{", "}", or "$" : "' + name + '"')
         return
 
     table[name] = value

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -497,7 +497,8 @@ def eval_text(text, symbols):
             return eval(s, global_symbols, symbols)
         except Exception as e:
             # re-raise as XacroException to add more context
-            raise XacroException(exc=e, suffix="when evaluating expression '%s'" % s)
+            raise XacroException(exc=e,
+                suffix=os.linesep + "when evaluating expression '%s'" % s)
 
     def handle_extension(s):
         return eval_extension("$(%s)" % s)

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -125,7 +125,10 @@ def check_deprecated_tag(tag_name):
 def eval_extension(s):
     if s == '$(cwd)':
         return os.getcwd()
-    return substitution_args.resolve_args(s, context=substitution_args_context, resolve_anon=False)
+    try:
+        return substitution_args.resolve_args(s, context=substitution_args_context, resolve_anon=False)
+    except substitution_args.ArgException as e:
+        raise XacroException("Undefined substitution argument '%s'" % str(e))
 
 
 # Better pretty printing of xml

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -405,7 +405,7 @@ class TestXacro(TestXacroCommentsIgnored):
             self.assert_matches(self.quick_xacro(input.format(glob=pattern)), result)
 
     def test_include_nonexistent(self):
-        self.assertRaises(xacro.XacroException,
+        self.assertRaises(IOError,
                           self.quick_xacro, '''<a xmlns:xacro="http://www.ros.org/xacro">
                              <xacro:include filename="include-nada.xml" /></a>''')
 

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -673,7 +673,7 @@ class TestXacro(TestXacroCommentsIgnored):
 </robot>''')
 
     def test_recursive_bad_math(self):
-        self.assertRaises(ZeroDivisionError,
+        self.assertRaises(xacro.XacroException,
             self.quick_xacro, '''\
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="x" value="0"/>


### PR DESCRIPTION
This is an attempt to improve error reporting to the normal xacro user. So far it was rather difficult to figure out, which piece of code (particularly which file) caused a certain error. With the proposed patches, xacro keeps track of its processed file stack and the function print_location() can be used to report it at any place. (With #75 I added recursive file reporting already, but that wasn't flexible enough to report the file stack anytime). 

The PR partially reverts #75 in the sense, that the `filename` argument that was passed through a lot of functions, is removed again. Instead, there is a global variable `filestack` where push/pop a newly processed file onto/from. This allows to store the filestack together with a macro definition allowing to know where a macro was defined when it will fail later during instantiation.

Further, I enabled XacroException to wrap another exception and augment its error message with some other information prepended or appended (which was used in the last three commits).

As you might have noted already, this commit builds on (and includes #82). Due to some overlapping changes, it wasn't possible to file them as separate PRs.

@codebot: I have some more feature extensions in the pipeline, namely yaml-import (of dict properties),
dynamically named element tags (through renaming), better handling of XML comments, and namespacing for includes. Please, give me a shout when you have some time to review them.
