### PR TITLE
check for consistency of xml namespaces on xacro:include

### DIFF
--- a/test/robots/pr2/common.xacro
+++ b/test/robots/pr2/common.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:property name="M_PI" value="3.1415926535897931" />
   <xacro:property name="VELOCITY_LIMIT_SCALE" value="0.6" />

--- a/test/robots/pr2/pr2.urdf.xacro
+++ b/test/robots/pr2/pr2.urdf.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-       xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://ros.org/wiki/xacro"
        name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->


### PR DESCRIPTION
Including another document might bring in inconsistent namespace declarations.
Previously, the parent's namespaces were simply replaced. Now they are kept and a warning message is issued.
Due to some inconsistencies in the pr2 example, I had to fix those.
