### PR TITLE
yaml support

### DIFF
--- a/test/include1.xacro
+++ b/test/include1.xacro
@@ -1,0 +1,4 @@
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<xacro:property name="var" value="1"/>
+	<xacro:macro name="foo1"><inc1/></xacro:macro>
+</a>

--- a/test/include2.xacro
+++ b/test/include2.xacro
@@ -1,0 +1,4 @@
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<xacro:property name="var" value="2"/>
+	<xacro:macro name="foo2"><inc2/></xacro:macro>
+</a>

--- a/test/settings.yaml
+++ b/test/settings.yaml
@@ -1,0 +1,9 @@
+arms:
+  inc1:
+    file:  include1.xacro
+    macro: foo1
+  inc2:
+    file:  include2.xacro
+    macro: foo2
+    props:
+      port: 4242

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -885,6 +885,19 @@ class TestXacroInorder(TestXacro):
         super(TestXacroInorder, self).__init__(*args, **kwargs)
         self.in_order = True
 
+    def test_yaml_support(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="type" value="$(arg type)"/>
+  <xacro:include filename="${settings['arms'][type]['file']}"/>
+  <xacro:call macro="${settings['arms'][type]['macro']}"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><{tag}/></a>'''
+        for i in ['inc1', 'inc2']:
+            self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
+                                res.format(tag=i))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I added `yaml` support to load a `dict` property from yaml. 
Having more complex, hierarchical properties turned out to be very useful in our setup where we compose a `robot_description` from some basic scaffold attaching arms and tools as dynamically specified on the command line. The properties of those robot components are summarized in a yaml file which can now be loaded into `xacro` and used for evaluation. Syntax is as easy as:
`${load_yaml('file.yaml')}`

A unittest illustrates basic usage.
