### PR TITLE
fix evaluation (#83)

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -194,7 +194,7 @@ class Table:
             try:
                 # try to evaluate as literal, e.g. number, boolean, etc.
                 # this is needed to handle numbers in property definitions as numbers, not strings
-                evaluated = ast.literal_eval(value)
+                evaluated = ast.literal_eval(value.strip())
                 # However, (simple) list, tuple, dict expressions will be evaluated as such too,
                 # which would break expected behaviour. Thus we only accept the evaluation otherwise.
                 if not isinstance(evaluated, (list, dict, tuple)):

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -681,7 +681,7 @@ def eval_all(root, macros={}, symbols=Table()):
                     raise XacroException("Argument name missing")
                 default = node.getAttribute('default')
                 if default and name not in substitution_args_context['arg']:
-                    substitution_args_context['arg'][name] = default
+                    substitution_args_context['arg'][name] = eval_text(default, symbols)
 
                 node.parentNode.removeChild(node)
                 node = None

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -171,7 +171,7 @@ def fixed_writexml(self, writer, indent="", addindent="", newl=""):
         for node in self.childNodes:
             # skip whitespace-only text nodes
             if node.nodeType == xml.dom.minidom.Node.TEXT_NODE and \
-               not node.data.strip():
+                    (not node.data or node.data.isspace()):
                 continue
             node.writexml(writer, indent + addindent, addindent, newl)
         writer.write("%s</%s>%s" % (indent, self.tagName, newl))

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -878,6 +878,20 @@ class TestXacro(TestXacroCommentsIgnored):
   <a prop="0.2"/>
 </a>''')
 
+    def test_transitive_arg_evaluation(self):
+        self.assert_matches(
+                self.quick_xacro('''\
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="foo" default="0.5"/>
+  <xacro:arg name="bar" default="$(arg foo)"/>
+  <xacro:property name="prop" value="$(arg bar)" />
+  <a prop="${prop-0.3}"/>
+</a>
+'''),'''\
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <a prop="0.2"/>
+</a>''')
+
 
 # test class for in-order processing
 class TestXacroInorder(TestXacro):

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -563,8 +563,8 @@ class TestXacro(TestXacroCommentsIgnored):
         self.assert_matches(
                 self.quick_xacro('''\
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="a" value="42"/>
-  <xacro:property name="a2" value="${2*a}"/>
+  <xacro:property name="a" value=" 42 "/>
+  <xacro:property name="a2" value="${ 2 * a }"/>
   <a doubled="${a2}"/>
 </robot>'''),
                 '''\


### PR DESCRIPTION
This fixes #83. I decided for silently stripping away whitespace enclosing literals and evaluation expressions:

``` xml
<xacro:property name="a" value=" 42 "/>
<xacro:property name="b" value=" ${a} "/>
```

Hence, both properties will evaluate to the numerical value 42.

Second commit allows to transitively evaluate substitution args.

Third one is for efficiency only.
