### PR TITLE
allow renaming of element names

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -644,6 +644,17 @@ def eval_all(node, macros, symbols):
                 remove_previous_comments(node)
                 replace_node(node, by=None)
 
+            elif node.tagName == 'xacro:rename' \
+                    and check_deprecated_tag(node.tagName):
+                name = node.getAttribute('xacro:name')
+                if name is None:
+                    raise XacroException("xacro:rename: 'xacro:name' attribute missing")
+                else:
+                    node.removeAttribute('xacro:name')
+
+                node.nodeName = node.tagName = eval_text(name, symbols)
+                continue  # re-process the node with new tagName
+
             elif node.tagName in ['if', 'xacro:if', 'unless', 'xacro:unless'] \
                     and check_deprecated_tag(node.tagName):
                 remove_previous_comments(node)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -233,6 +233,15 @@ class TestXacro(TestXacroCommentsIgnored):
                           '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
                           <xacro:undefined><foo/><bar/></xacro:undefined></a>''')
 
+    def test_xacro_rename(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo" params="name"><xacro:rename xacro:name="${name}"/></xacro:macro>
+  <xacro:foo name="A"/>
+  <xacro:foo name="B"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><A/><B/></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
     def test_inorder_processing(self):
         src = '''<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="foo" value="1.0"/>


### PR DESCRIPTION
Recently I wanted to define a macro that should create a XML fragment with dynamic tag names,
i.e. tag names generated from macro parameters. Unfortunately, this wasn't yet handled by xacro.
This is a simple patch to allow it. Do you like the `<xacro:rename>` syntax?

``` xml
<xacro:rename xacro:name="<new element name>" att="val" ...>
   ... content ... 
</xacro:rename>
```

By purpose, I've put the name attribute into the xacro namespace as well - to allow for a native name attribute within the generated element too.

Having xacro extended towards dynamic tag name generation, there is still one missing feature: Generating dynamic attribute names. However, I don't yet have a nice syntax for it yet. One could think of

`````` xml
<xacro:attribute name="" value=""/>```
``````
