### PR TITLE
allow namespacing for xacro:include's

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -211,7 +211,7 @@ def fixed_writexml(self, writer, indent="", addindent="", newl=""):
 xml.dom.minidom.Element.writexml = fixed_writexml
 
 
-class Table:
+class Table(object):
     def __init__(self, parent=None):
         self.parent = parent
         self.table = {}
@@ -276,6 +276,19 @@ class Table:
             s += "\n  parent: "
             s += str(self.parent)
         return s
+
+class NameSpace(object):
+    # dot access (namespace.property) is forwarded to getitem()
+    def __getattr__(self, item):
+        return self.__getitem__(item)
+
+class PropertyNameSpace(Table, NameSpace):
+    def __init__(self, parent=None):
+        super(PropertyNameSpace, self).__init__(parent)
+
+class MacroNameSpace(dict, NameSpace):
+    def __init__(self, *args, **kwargs):
+        super(MacroNameSpace, self).__init__(*args, **kwargs)
 
 
 class QuickLexer(object):
@@ -408,15 +421,26 @@ def import_xml_namespaces(parent, attributes):
                 parent.setAttribute(name, value)
 
 
-def process_include(elt, symbols, func):
+def process_include(elt, macros, symbols, func):
     included = []
+    namespace_spec = elt.getAttribute('ns')
+    if namespace_spec:
+        try:
+            namespace_spec = eval_text(namespace_spec, symbols)
+            macros[namespace_spec] = ns_macros = MacroNameSpace()
+            symbols[namespace_spec] = ns_symbols = PropertyNameSpace()
+            macros = ns_macros
+            symbols = ns_symbols
+        except TypeError:
+            raise XacroException('namespaces are supported with --inorder option only')
+
     for filename in get_include_files(elt, symbols):
         # extend filestack
         oldstack = push_file(filename)
         include = parse(None, filename).documentElement
 
         # recursive call to func
-        func(include)
+        func(include, macros, symbols)
         included.append(include)
         import_xml_namespaces(elt.parentNode, include.attributes)
 
@@ -429,12 +453,12 @@ def process_include(elt, symbols, func):
 
 
 # @throws XacroException if a parsing error occurs with an included document
-def process_includes(elt):
+def process_includes(elt, macros=None, symbols=None):
     elt = first_child_element(elt)
     while elt:
         next = next_sibling_element(elt)
         if is_include(elt):
-            process_include(elt, {}, process_includes)
+            process_include(elt, macros, symbols, process_includes)
         else:
             process_includes(elt)
 
@@ -453,7 +477,7 @@ def grab_macro(elt, macros):
     _, defs = macros.get(name, (None, []))
     defs.append(filestack)
 
-    macros['xacro:' + name] = macros[name] = (elt, defs)
+    macros[name] = (elt, defs)
     replace_node(elt, by=None)
 
 
@@ -547,6 +571,104 @@ def eval_text(text, symbols):
         return ''.join(map(str, results))
 
 
+def handle_dynamic_macro_call(node, macros, symbols):
+    name = node.getAttribute('macro')
+    if not name:
+        raise XacroException("xacro:call is missing the 'macro' attribute")
+    name = str(eval_text(name, symbols))
+
+    # remove 'macro' attribute and rename tag with resolved macro name
+    node.removeAttribute('macro')
+    node.tagName = name
+    # forward to handle_macro_call
+    result = handle_macro_call(node, name, macros, symbols)
+    if not result:  # we expect the call to succeed
+        raise XacroException("unknown macro name '%s' in xacro:call" % name)
+    return True
+
+def handle_macro_call(node, name, macros, symbols):
+    if name.startswith('xacro:'):
+        name = name.replace('xacro:', '')
+
+    try:
+        m = None
+        m = macros[name]  # try simple macro resolution from macros dict
+    except KeyError:
+        pass
+
+    try:
+        #  using eval allows to employ python's resolving mechanism
+        #  to also resolve macros in namespaces, e.g. ns1.ns2.macro
+        m = m or eval(name, dict(__builtins__={}), macros)
+        body = m[0].cloneNode(deep=True)
+    except (NameError, TypeError):  # that wasn't a known macro
+        # TODO If deprecation runs out, this test should be moved up front
+        if node.tagName == 'xacro:call':
+            return handle_dynamic_macro_call(node, macros, symbols)
+        return False
+
+    params = body.getAttribute('params').split()
+
+    # TODO should be moved to grab_macro, storing defaultMap as field in macro
+    # Parse default values for any parameters
+    defaultmap = {}
+    for param in params[:]:
+        splitParam = param.split(':=')
+
+        if len(splitParam) == 2:
+            defaultmap[splitParam[0]] = splitParam[1]
+            params.remove(param)
+            params.append(splitParam[0])
+
+        elif len(splitParam) != 1:
+            raise XacroException("Invalid parameter definition", macro=m)
+
+    # Expands the macro
+    scoped = Table(symbols)  # new local name space for macro evaluation
+    for name, value in node.attributes.items():
+        if name not in params:
+            raise XacroException("Invalid parameter \"%s\"" % str(name), macro=m)
+        params.remove(name)
+        scoped[name] = eval_text(value, symbols)
+
+    # Pulls out the block arguments, in order
+    eval_all(node, macros, symbols)  # for calling eval_all
+    block = first_child_element(node)
+    for param in params[:]:
+        if param[0] == '*':
+            if not block:
+                raise XacroException("Not enough blocks", macro=m)
+            params.remove(param)
+            scoped[param] = block
+            block = next_sibling_element(block)
+
+    if block is not None:
+        raise XacroException("Unused block \"%s\"" % block.tagName, macro=m)
+
+    # Try to load defaults for any remaining non-block parameters
+    for param in params[:]:
+        if param[0] != '*' and param in defaultmap:
+            scoped[param] = defaultmap[param]
+            params.remove(param)
+
+    if params:
+        raise XacroException("Undefined parameters [%s]" % ",".join(params), macro=m)
+
+    try:
+        eval_all(body, macros, scoped)
+    except Exception as e:
+        if hasattr(e, 'macros'):
+            e.macros.append(m)
+        else:
+            e.macros = [m]
+        raise
+
+    # Replaces the macro node with the expansion
+    remove_previous_comments(node)
+    replace_node(node, by=body, content_only=True)
+    return True
+
+
 def get_boolean_value(value, condition):
     """
     Return a boolean value that corresponds to the given Xacro condition value.
@@ -622,7 +744,7 @@ def eval_all(node, macros, symbols):
                 replace_node(node, by=block.cloneNode(deep=True), content_only=content_only)
 
             elif is_include(node):
-                process_include(node, symbols, lambda doc: eval_all(doc, macros, symbols))
+                process_include(node, macros, symbols, eval_all)
 
             elif node.tagName in ['property', 'xacro:property'] \
                     and check_deprecated_tag(node.tagName):
@@ -658,85 +780,8 @@ def eval_all(node, macros, symbols):
                 else:
                     replace_node(node, by=None)
 
-            elif node.tagName in macros:
-                m = macros[node.tagName]
-                body = m[0].cloneNode(deep=True)
-                params = body.getAttribute('params').split()
-
-                # TODO should be moved to grab_macro, storing defaultMap as field in macro
-                # Parse default values for any parameters
-                defaultmap = {}
-                for param in params[:]:
-                    splitParam = param.split(':=')
-
-                    if len(splitParam) == 2:
-                        defaultmap[splitParam[0]] = splitParam[1]
-                        params.remove(param)
-                        params.append(splitParam[0])
-
-                    elif len(splitParam) != 1:
-                        raise XacroException("Invalid parameter definition", macro=m)
-
-                # Expands the macro
-                scoped = Table(symbols)  # new local name space for macro evaluation
-                for name, value in node.attributes.items():
-                    if name not in params:
-                        raise XacroException("Invalid parameter \"%s\"" % str(name), macro=m)
-                    params.remove(name)
-                    scoped[name] = eval_text(value, symbols)
-
-                # Pulls out the block arguments, in order
-                eval_all(node, macros, symbols)  # for calling eval_all
-                block = first_child_element(node)
-                for param in params[:]:
-                    if param[0] == '*':
-                        if not block:
-                            raise XacroException("Not enough blocks", macro=m)
-                        params.remove(param)
-                        scoped[param] = block
-                        block = next_sibling_element(block)
-
-                if block is not None:
-                    raise XacroException("Unused block \"%s\"" % block.tagName, macro=m)
-
-                # Try to load defaults for any remaining non-block parameters
-                for param in params[:]:
-                    if param[0] != '*' and param in defaultmap:
-                        scoped[param] = defaultmap[param]
-                        params.remove(param)
-
-                if params:
-                    raise XacroException("Undefined parameters [%s]" % ",".join(params), macro=m)
-
-                try:
-                    eval_all(body, macros, scoped)
-                except Exception as e:
-                    if hasattr(e, 'macros'):
-                        e.macros.append(m)
-                    else:
-                        e.macros = [m]
-                    raise
-
-                # Replaces the macro node with the expansion
-                remove_previous_comments(node)
-                replace_node(node, by=body, content_only=True)
-
-            # Handling this one after the normal macro handling will resolve an existing macro 'call' as usual
-            # TODO If deprecation runs out, it should be moved before macro handling
-            elif node.tagName == 'xacro:call':
-                name = node.getAttribute('macro')
-                if name is None:
-                    raise XacroException("xacro:call is missing the 'macro' attribute")
-
-                name = str(eval_text(name, symbols))
-                if name not in macros:
-                    raise XacroException("unknown macro name '%s' in xacro:call" % name)
-
-                # remove 'macro' attribute and rename tag with resolved macro name
-                node.removeAttribute('macro')
-                # TODO prepend xacro namespace
-                node.tagName = name
-                continue  # re-process the node with new tagName
+            elif handle_macro_call(node, node.tagName, macros, symbols):
+                pass  # handle_macro_call does all the work of expanding the macro
 
             else:
                 # these are the non-xacro tags

--- a/test/include1.xacro
+++ b/test/include1.xacro
@@ -1,4 +1,4 @@
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<xacro:property name="var" value="1"/>
-	<xacro:macro name="foo1"><inc1/></xacro:macro>
+	<xacro:macro name="foo"><inc1/></xacro:macro>
 </a>

--- a/test/include2.xacro
+++ b/test/include2.xacro
@@ -1,4 +1,4 @@
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<xacro:property name="var" value="2"/>
-	<xacro:macro name="foo2"><inc2/></xacro:macro>
+	<xacro:macro name="foo"><inc2/></xacro:macro>
 </a>

--- a/test/settings.yaml
+++ b/test/settings.yaml
@@ -1,9 +1,9 @@
 arms:
   inc1:
     file:  include1.xacro
-    macro: foo1
+    macro: foo
   inc2:
     file:  include2.xacro
-    macro: foo2
+    macro: foo
     props:
       port: 4242

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -150,6 +150,21 @@ class TestMatchXML(unittest.TestCase):
                                     '''<a><b/></a>''', [xml.dom.Node.COMMENT_NODE]))
 
 
+class TestXacroFunctions(unittest.TestCase):
+    def test_is_valid_name(self):
+        self.assertTrue(xacro.is_valid_name("_valid_name_123"))
+        self.assertFalse(xacro.is_valid_name('pass'))     # syntactically correct keyword
+        self.assertFalse(xacro.is_valid_name('foo '))     # trailing whitespace
+        self.assertFalse(xacro.is_valid_name(' foo'))     # leading whitespace
+        self.assertFalse(xacro.is_valid_name('1234'))     # number
+        self.assertFalse(xacro.is_valid_name('1234abc'))  # number and letters
+        self.assertFalse(xacro.is_valid_name(''))         # empty string
+        self.assertFalse(xacro.is_valid_name('   '))      # whitespace only
+        self.assertFalse(xacro.is_valid_name('foo bar'))  # several tokens
+        self.assertFalse(xacro.is_valid_name('no-dashed-names-for-you'))
+        self.assertFalse(xacro.is_valid_name('invalid.too'))  # dot separates fields
+
+
 # base class providing some convenience functions
 class TestXacroBase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -202,6 +217,21 @@ class TestXacro(TestXacroCommentsIgnored):
     def __init__(self, *args, **kwargs):
         super(TestXacroCommentsIgnored, self).__init__(*args, **kwargs)
         self.ignore_nodes = []
+
+    def test_invalid_macro_name(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+        <xacro:macro name="deprecated-name"><foo/></xacro:macro>
+        <deprecated-name/>
+        </a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><foo/></a>'''
+        with capture_stderr(self.quick_xacro, src) as (result, output):
+            self.assert_matches(result, res)
+            self.assertTrue(output)
+
+    def test_invalid_property_name(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+        <xacro:property name="invalid.name"/></a>'''
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
 
     def test_dynamic_macro_names(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -433,6 +433,25 @@ class TestXacro(TestXacroCommentsIgnored):
 <inc1/><inc1/>
 <subdir_inc1/><subdir_inc1/><inc1/></a>''')
 
+    def test_include_with_namespace(self):
+        doc = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="var" value="main"/>
+  <xacro:include filename="include1.xacro" ns="A"/>
+  <xacro:include filename="include2.xacro" ns="B"/>
+  <A.foo/><B.foo/>
+  <main var="${var}" A="${2*A.var}" B="${B.var+1}"/>
+</a>'''
+        result = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <inc1/><inc2/><main var="main" A="2" B="3"/>
+</a>'''
+
+        if self.in_order:
+            self.assert_matches(self.quick_xacro(doc), result)
+        else:
+            self.assertRaises(xacro.XacroException, self.quick_xacro, doc)
+
     def test_boolean_if_statement(self):
         self.assert_matches(
                 self.quick_xacro('''\


### PR DESCRIPTION
Composing more complex xacro documents from several, typically 3rd party sources, may cause name clashes. To avoid this, I suggest to allow for namespacing of macros and properties defined within an included file.
Employing python evaluation not only for properties, but also for macro names, I could quite easily add this feature.

However, this comes with a drawback (as before with properties): Valid macro (and property) names must be valid python identifiers. Particularly dashes, points, etc are not allowed anymore: `this-is-invalid`.

For now, macro resolving uses the old strategy first and resorts to python evaluation on failure only - keeping existing files valid. For invalid properties an exception is raised, forcing people to change names.
(For properties the risk of invalid names is smaller, because minus signs were interpreted as such before too.)
