### PR TITLE
minor fixes

### DIFF
--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -26,7 +26,6 @@ add_custom_target(${PROJECT_NAME}_xacro_generated_to_devel_space_ ALL)
 ##   xacro_add_xacro_file(${xacro_file} INORDER REMAP bar:=foo foo:=bar)
 ##   list(APPEND xacro_outputs ${XACRO_OUTPUT_FILE})
 ## endforeach()
-## add_custom_target(xacro_target ALL DEPENDS ${xacro_outputs})
 ## xacro_install(xacro_target ${xacro_outputs} DESTINATION xml)
 ##
 ## Be aware, that xacro_install() is required to install into both, install and devel space.

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -854,6 +854,9 @@ def process_cli_args(argv, require_input=True):
     filtered_args = [a for a in argv if REMAP not in a]  # filter-out REMAP args
     (options, pos_args) = parser.parse_args(filtered_args)
 
+    if options.in_order and options.just_includes:
+        parser.error("options --inorder and --includes are mutually exclusive")
+
     if len(pos_args) != 1:
         if require_input:
             parser.error("expected exactly one input file as argument")
@@ -907,7 +910,9 @@ def process_doc(doc,
     # if not yet defined: initialize filestack
     if not filestack: restore_filestack([None])
 
-    if just_deps or just_includes:
+    # inorder processing requires to process the whole document for deps too
+    # because filenames might be specified via properties or macro parameters
+    if (just_deps or just_includes) and not in_order:
         process_includes(doc.documentElement)
         return
 

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -789,11 +789,11 @@ def eval_all(node, macros, symbols):
                 remove_previous_comments(node)
                 replace_node(node, by=None)
 
-            elif node.tagName == 'xacro:rename' \
+            elif node.tagName == 'xacro:element' \
                     and check_deprecated_tag(node.tagName):
                 name = node.getAttribute('xacro:name')
                 if name is None:
-                    raise XacroException("xacro:rename: 'xacro:name' attribute missing")
+                    raise XacroException("xacro:element: 'xacro:name' attribute missing")
                 else:
                     node.removeAttribute('xacro:name')
 

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -993,7 +993,7 @@ def main():
             sys.exit(2)  # gracefully exit with error condition
 
     if opts.just_deps:
-        out.write(" ".join(all_includes))
+        out.write(" ".join(set(all_includes)))
         print()
         return
     if opts.just_includes:

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -269,9 +269,9 @@ class TestXacro(TestXacroCommentsIgnored):
                           '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
                           <xacro:undefined><foo/><bar/></xacro:undefined></a>''')
 
-    def test_xacro_rename(self):
+    def test_xacro_element(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="foo" params="name"><xacro:rename xacro:name="${name}"/></xacro:macro>
+  <xacro:macro name="foo" params="name"><xacro:element xacro:name="${name}"/></xacro:macro>
   <xacro:foo name="A"/>
   <xacro:foo name="B"/>
 </a>'''


### PR DESCRIPTION
some little fixes - see the commit messages

I would like to start a migration path towards `--inorder` processing. Maintaining both code branches becomes more and more tedious. 
I suggest to keep the old processing as a default in `Jade`, but issue a deprecation warning, pointing to the [wiki](http://wiki.ros.org/xacro#Processing_Order). In the next release --inorder processing could become default with an option providing the old behavior as fallback.

What do you think?
