### PR TITLE
cleanup + finalize

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -913,6 +913,10 @@ def print_location(filestack, err=None, file=sys.stderr):
 
 def main():
     opts, input_file = process_args(sys.argv[1:])
+    if opts.in_order == False:
+        warning("Traditional processing is deprecated. Switch to --inorder processing!")
+        message("To check for compatibility of your document, use option --check-order.", color='yellow')
+        message("For more infos, see http://wiki.ros.org/xacro#Processing_Order", color='yellow')
 
     try:
         restore_filestack([input_file])

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -618,7 +618,7 @@ def handle_macro_call(node, name, macros, symbols):
         if param[0] == '*': continue
         value = m.defaultmap.get(param, None)
         if value is not None:
-            scoped[param] = value
+            scoped[param] = eval_text(value, symbols)
             params.remove(param)
 
     if params:

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -798,10 +798,10 @@ def parse(inp, filename=None):
     if inp is None:
         try:
             inp = f = open(filename)
-        except IOError:
+        except IOError as e:
             # do not report currently processed file as "in file ..."
             filestack.pop()
-            raise
+            raise XacroException(e.strerror + ": " + e.filename)
 
     try:
         if isinstance(inp, _basestr):

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -708,8 +708,7 @@ def eval_all(node, macros, symbols):
                 remove_previous_comments(node)
                 replace_node(node, by=None)
 
-            elif node.tagName == 'xacro:element' \
-                    and check_deprecated_tag(node.tagName):
+            elif node.tagName == 'xacro:element':
                 name = eval_text(*reqd_attrs(node, ['xacro:name']), symbols=symbols)
                 if not name:
                     raise XacroException("xacro:element: empty name")
@@ -717,6 +716,14 @@ def eval_all(node, macros, symbols):
                 node.removeAttribute('xacro:name')
                 node.nodeName = node.tagName = name
                 continue  # re-process the node with new tagName
+
+            elif node.tagName == 'xacro:attribute':
+                name, value = [eval_text(a, symbols) for a in reqd_attrs(node, ['name', 'value'])]
+                if not name:
+                    raise XacroException("xacro:attribute: empty name")
+
+                node.parentNode.setAttribute(name, value)
+                replace_node(node, by=None)
 
             elif node.tagName in ['if', 'xacro:if', 'unless', 'xacro:unless'] \
                     and check_deprecated_tag(node.tagName):

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -43,7 +43,7 @@ from roslaunch import substitution_args
 from rosgraph.names import load_mappings, REMAP
 from optparse import OptionParser
 from copy import deepcopy
-from .color import warning, error, message
+from .color import warning, error, message, colorize
 from .xmlutils import *
 
 try:
@@ -792,9 +792,14 @@ def eval_all(node, macros, symbols):
 
         node = next
 
+class ColoredOptionParser(OptionParser):
+    def error(self, message):
+        msg = colorize(message, 'red')
+        OptionParser.error(self, msg)
+
 
 def process_cli_args(argv, require_input=True):
-    parser = OptionParser(usage="usage: %prog [options] <input>")
+    parser = ColoredOptionParser(usage="usage: %prog [options] <input>")
     parser.add_option("-o", dest="output", metavar="FILE",
                       help="write output to FILE instead of stdout")
     parser.add_option("--oldorder", action="store_false", dest="in_order",

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -773,8 +773,10 @@ def process_cli_args(argv, require_input=True):
     parser = OptionParser(usage="usage: %prog [options] <input>")
     parser.add_option("-o", dest="output", metavar="FILE",
                       help="write output to FILE instead of stdout")
+    parser.add_option("--oldorder", action="store_false", dest="in_order",
+                      help="use traditional processing order [deprecated default]")
     parser.add_option("--inorder", action="store_true", dest="in_order",
-                      help="evaluate document in read order")
+                      help="use processing in read order")
     parser.add_option("--deps", action="store_true", dest="just_deps",
                       help="print file dependencies")
     parser.add_option("--includes", action="store_true", dest="just_includes",

--- a/src/xacro/cli.py
+++ b/src/xacro/cli.py
@@ -68,6 +68,9 @@ def process_args(argv, require_input=True):
                       help="use traditional processing order [deprecated default]")
     parser.add_option("--inorder", action="store_true", dest="in_order",
                       help="use processing in read order")
+    parser.add_option("--check-order", action="store_true", dest="do_check_order",
+                      help="check document for inorder processing", default=False)
+
     parser.add_option("--deps", action="store_true", dest="just_deps",
                       help="print file dependencies")
     parser.add_option("--includes", action="store_true", dest="just_includes",
@@ -99,6 +102,9 @@ def process_args(argv, require_input=True):
 
     if options.in_order and options.just_includes:
         parser.error("options --inorder and --includes are mutually exclusive")
+
+    if options.do_check_order:
+        options.in_order = True  # check-order implies inorder
 
     if len(pos_args) != 1:
         if require_input:

--- a/src/xacro/cli.py
+++ b/src/xacro/cli.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2015, Open Source Robotics Foundation, Inc.
+# Copyright (c) 2013, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Open Source Robotics Foundation, Inc.
+#       nor the names of its contributors may be used to endorse or promote
+#       products derived from this software without specific prior
+#       written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Authors: Stuart Glaser, William Woodall, Robert Haschke
+# Maintainer: Morgan Quigley <morgan@osrfoundation.org>
+
+import textwrap
+from optparse import OptionParser, IndentedHelpFormatter
+from rosgraph.names import load_mappings, REMAP
+from .color import colorize
+
+class ColoredOptionParser(OptionParser):
+    def error(self, message):
+        msg = colorize(message, 'red')
+        OptionParser.error(self, msg)
+
+
+_original_wrap = textwrap.wrap
+def wrap_with_newlines(text, width, **kwargs):
+    result = []
+    for paragraph in text.split('\n'):
+        result.extend(_original_wrap(paragraph, width, **kwargs))
+    return result
+
+class IndentedHelpFormatterWithNL(IndentedHelpFormatter):
+    def __init__(self, *args, **kwargs):
+        IndentedHelpFormatter.__init__(self, *args, **kwargs)
+
+    def format_option(self, text):
+        textwrap.wrap, old = wrap_with_newlines, textwrap.wrap
+        result = IndentedHelpFormatter.format_option(self, text)
+        textwrap.wrap = old
+        return result
+
+
+def process_args(argv, require_input=True):
+    parser = ColoredOptionParser(usage="usage: %prog [options] <input>",
+                                 formatter=IndentedHelpFormatterWithNL())
+    parser.add_option("-o", dest="output", metavar="FILE",
+                      help="write output to FILE instead of stdout")
+    parser.add_option("--oldorder", action="store_false", dest="in_order",
+                      help="use traditional processing order [deprecated default]")
+    parser.add_option("--inorder", action="store_true", dest="in_order",
+                      help="use processing in read order")
+    parser.add_option("--deps", action="store_true", dest="just_deps",
+                      help="print file dependencies")
+    parser.add_option("--includes", action="store_true", dest="just_includes",
+                      help="only process includes")
+    parser.add_option("--xacro-ns", action="store_false", default=True, dest="xacro_ns",
+                      help="require xacro namespace prefix for xacro tags")
+
+    # verbosity options
+    parser.add_option("-q", action="store_const", dest="verbosity", const=0,
+                      help="quiet operation suppressing warnings")
+    parser.add_option("-v", action="count", dest="verbosity",
+                      help="increase verbosity")
+    parser.add_option("--verbosity", metavar='level', dest="verbosity", type='int',
+                      help=textwrap.dedent("""\
+                      set verbosity level
+                      0: quiet, suppressing warnings
+                      1: default, showing warnings and error locations
+                      2: show stack trace
+                      3: log property definitions and usage on top level
+                      4: log property definitions and usage on all levels"""))
+
+    # process substitution args
+    mappings = load_mappings(argv)
+
+    parser.set_defaults(in_order=False, just_deps=False, just_includes=False,
+                        verbosity=1)
+    filtered_args = [a for a in argv if REMAP not in a]  # filter-out REMAP args
+    (options, pos_args) = parser.parse_args(filtered_args)
+
+    if options.in_order and options.just_includes:
+        parser.error("options --inorder and --includes are mutually exclusive")
+
+    if len(pos_args) != 1:
+        if require_input:
+            parser.error("expected exactly one input file as argument")
+        else:
+            pos_args = [None]
+
+    options.mappings = mappings
+    return options, pos_args[0]

--- a/src/xacro/color.py
+++ b/src/xacro/color.py
@@ -9,16 +9,20 @@ def is_tty(stream): # taken from catkin_tools/common.py
     return hasattr(stream, 'isatty') and stream.isatty()
 
 
+def colorize(msg, color, file=sys.stderr, alt_text=None):
+    if color and is_tty(file):
+        return '\033[%dm%s\033[0m' % (_ansi[color], msg)
+    elif alt_text:
+        return '%s%s' % (alt_text, msg)
+    else:
+        return msg
+
+
 def message(msg, *args, **kwargs):
     file  = kwargs.get('file', sys.stderr)
     alt_text = kwargs.get('alt_text', None)
     color = kwargs.get('color', None)
-
-    if color and is_tty(file):
-        msg = '\033[%dm%s\033[0m' % (_ansi[color], msg)
-    elif alt_text:
-        msg = '%s%s' % (alt_text, msg)
-    print(msg, *args, file=file)
+    print(colorize(msg, color, file, alt_text), *args, file=file)
 
 
 def warning(*args, **kwargs):

--- a/src/xacro/xmlutils.py
+++ b/src/xacro/xmlutils.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2015, Open Source Robotics Foundation, Inc.
+# Copyright (c) 2013, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Open Source Robotics Foundation, Inc.
+#       nor the names of its contributors may be used to endorse or promote
+#       products derived from this software without specific prior
+#       written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Authors: Stuart Glaser, William Woodall, Robert Haschke
+# Maintainer: Morgan Quigley <morgan@osrfoundation.org>
+
+import xml
+from .color import warning
+
+def first_child_element(elt):
+    c = elt.firstChild
+    while c and c.nodeType != xml.dom.Node.ELEMENT_NODE:
+        c = c.nextSibling
+    return c
+
+
+def next_sibling_element(node):
+    c = node.nextSibling
+    while c and c.nodeType != xml.dom.Node.ELEMENT_NODE:
+        c = c.nextSibling
+    return c
+
+
+def replace_node(node, by, content_only=False):
+    parent = node.parentNode
+
+    if by is not None:
+        if not isinstance(by, list):
+            by = [by]
+
+        # insert new content before node
+        for doc in by:
+            if content_only:
+                c = doc.firstChild
+                while c:
+                    n = c.nextSibling
+                    parent.insertBefore(c, node)
+                    c = n
+            else:
+                parent.insertBefore(doc, node)
+
+    # remove node
+    parent.removeChild(node)
+
+
+def attribute(tag, a):
+    """
+    Helper function to fetch a single attribute value from tag
+    :param tag (xml.dom.Element): DOM element node
+    :param a (str): attribute name
+    :return: attribute value if present, otherwise None
+    """
+    if tag.hasAttribute(a):
+        # getAttribute returns empty string for non-existent attributes,
+        # which makes it impossible to distinguish with empty values
+        return tag.getAttribute(a)
+    else:
+        return None
+
+
+def opt_attrs(tag, attrs):
+    """
+    Helper routine for fetching optional tag attributes
+    :param tag (xml.dom.Element): DOM element node
+    :param attrs [str]: list of attributes to fetch
+    """
+    return [attribute(tag, a) for a in attrs]
+
+
+def reqd_attrs(tag, attrs):
+    """
+    Helper routine for fetching required tag attributes
+    :param tag (xml.dom.Element): DOM element node
+    :param attrs [str]: list of attributes to fetch
+    :raise RuntimeError: if required attribute is missing
+    """
+    result = opt_attrs(tag, attrs)
+    for (res, name) in zip(result, attrs):
+        if res is None:
+            raise RuntimeError("%s: missing attribute '%s'" % (tag.nodeName, name))
+    return result
+
+
+def check_attrs(tag, required, optional):
+    """
+    Helper routine to fetch required and optional attributes
+    and complain about any additional attributes.
+    :param tag (xml.dom.Element): DOM element node
+    :param required [str]: list of required attributes
+    :param optional [str]: list of optional attributes
+    """
+    result = reqd_attrs(tag, required)
+    result.extend(opt_attrs(tag, optional))
+    allowed = required + optional
+    extra = [a for a in tag.attributes.keys() if a not in allowed]
+    if extra:
+        warning("%s: unknown attribute(s): %s" % (tag.nodeName, ', '.join(extra)))
+    return result
+
+
+# Better pretty printing of xml
+# Taken from http://ronrothman.com/public/leftbraned/xml-dom-minidom-toprettyxml-and-silly-whitespace/
+def fixed_writexml(self, writer, indent="", addindent="", newl=""):
+    # indent = current indentation
+    # addindent = indentation to add to higher levels
+    # newl = newline string
+    writer.write(indent + "<" + self.tagName)
+
+    attrs = self._get_attributes()
+    a_names = list(attrs.keys())
+    a_names.sort()
+
+    for a_name in a_names:
+        writer.write(" %s=\"" % a_name)
+        xml.dom.minidom._write_data(writer, attrs[a_name].value)
+        writer.write("\"")
+    if self.childNodes:
+        if len(self.childNodes) == 1 \
+           and self.childNodes[0].nodeType == xml.dom.minidom.Node.TEXT_NODE:
+            writer.write(">")
+            self.childNodes[0].writexml(writer, "", "", "")
+            writer.write("</%s>%s" % (self.tagName, newl))
+            return
+        writer.write(">%s" % newl)
+        for node in self.childNodes:
+            # skip whitespace-only text nodes
+            if node.nodeType == xml.dom.minidom.Node.TEXT_NODE and \
+                    (not node.data or node.data.isspace()):
+                continue
+            node.writexml(writer, indent + addindent, addindent, newl)
+        writer.write("%s</%s>%s" % (indent, self.tagName, newl))
+    else:
+        writer.write("/>%s" % newl)
+# replace minidom's function with ours
+xml.dom.minidom.Element.writexml = fixed_writexml
+
+

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -178,7 +178,7 @@ class TestXacroBase(unittest.TestCase):
     def quick_xacro(self, xml, cli=None, **kwargs):
         args = {}
         if cli:
-            opts, _ = xacro.process_cli_args(cli, require_input=False)
+            opts, _ = xacro.cli.process_args(cli, require_input=False)
             args.update(vars(opts))  # initialize with cli args
         args.update(dict(in_order = self.in_order))  # set in_order option from test class
         args.update(kwargs)  # explicit function args have highest priority

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -408,25 +408,23 @@ class TestXacro(TestXacroCommentsIgnored):
 </a>''')
 
     def test_multiple_blocks(self):
-        self.assert_matches(
-                self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-<xacro:macro name="foo" params="*block1 *block2">
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:macro name="foo" params="*block{A} *block{B}">
+  <xacro:insert_block name="block1" />
   <xacro:insert_block name="block2" />
-  <first>
-    <xacro:insert_block name="block1" />
-  </first>
 </xacro:macro>
 <xacro:foo>
-  <first_block />
-  <second_block />
+  <block1/>
+  <block2/>
 </xacro:foo>
-</a>'''),
-                '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <second_block />
-  <first>
-    <first_block />
-  </first>
-</a>''')
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<block{A}/>
+<block{B}/>
+</a>'''
+        # test both, reversal and non-reversal of block order
+        for d in [dict(A='1', B='2'), dict(A='2', B='1')]:
+            self.assert_matches(self.quick_xacro(src.format(**d)), res.format(**d))
 
     def test_integer_stays_integer(self):
         self.assert_matches(

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -349,6 +349,23 @@ class TestXacro(TestXacroCommentsIgnored):
   <the_foo result="42" />
 </a>''')
 
+    def test_property_scope_parent(self):
+        self.assert_matches(self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo"><xacro:property name="foo" value="42" scope="parent"/></xacro:macro>
+  <xacro:foo/><a foo="${foo}"/></a>'''),
+        '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><a foo="42"/></a>''')
+
+    def test_property_scope_global(self):
+        self.assert_matches(self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo">
+    <xacro:macro name="bar">
+      <xacro:property name="foo" value="42" scope="global"/>
+    </xacro:macro>
+    <xacro:bar/>
+  </xacro:macro>
+  <xacro:foo/><a foo="${foo}"/></a>'''),
+        '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><a foo="42"/></a>''')
+
     def test_math_ignores_spaces(self):
         self.assert_matches(
                 self.quick_xacro('''<a><f v="${0.9 / 2 - 0.2}" /></a>'''),

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -472,6 +472,13 @@ class TestXacro(TestXacroCommentsIgnored):
                           self.quick_xacro, '''<a xmlns:xacro="http://www.ros.org/xacro">
                              <xacro:include filename="include-nada.xml" /></a>''')
 
+    def test_include_deprecated(self):
+        # <include> tags with some non-trivial content should not issue the deprecation warning
+        src = '''<a><include filename="nada"><tag/></include></a>'''
+        with capture_stderr(self.quick_xacro, src) as (result, output):
+            self.assert_matches(result, src)
+            self.assertEqual(output, '')
+
     def test_include_from_variable(self):
         doc = '''<a xmlns:xacro="http://www.ros.org/xacro">
         <xacro:property name="file" value="include1.xml"/>

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1026,6 +1026,21 @@ class TestXacroInorder(TestXacro):
             self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
                                 res.format(tag=i))
 
+    def test_macro_default_param_evaluation_order(self):
+        src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:macro name="foo" params="arg:=${2*foo}">
+    <xacro:property name="foo" value="-"/>
+    <f val="${arg}"/>
+</xacro:macro>
+<xacro:property name="foo" value="${3*7}"/>
+<xacro:foo/>
+<xacro:property name="foo" value="*"/>
+<xacro:foo/>
+</a>'''
+        res='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<f val="42"/><f val="**"/></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -440,7 +440,7 @@ class TestXacro(TestXacroCommentsIgnored):
             self.assert_matches(self.quick_xacro(input.format(glob=pattern)), result)
 
     def test_include_nonexistent(self):
-        self.assertRaises(IOError,
+        self.assertRaises(xacro.XacroException,
                           self.quick_xacro, '''<a xmlns:xacro="http://www.ros.org/xacro">
                              <xacro:include filename="include-nada.xml" /></a>''')
 

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -261,7 +261,7 @@ class TestXacro(TestXacroCommentsIgnored):
         self.assertRaises(xacro.XacroException,
                           self.quick_xacro,
                           '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-                          <xacro:call name="foo"/></a>''')
+                          <xacro:call macro="foo"/></a>''')
 
     def test_macro_undefined(self):
         self.assertRaises(xacro.XacroException,

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -278,6 +278,17 @@ class TestXacro(TestXacroCommentsIgnored):
         res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><A/><B/></a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
+    def test_xacro_attribute(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo" params="name value">
+  <tag><xacro:attribute name="${name}" value="${value}"/></tag>
+  </xacro:macro>
+  <xacro:foo name="A" value="foo"/>
+  <xacro:foo name="B" value="bar"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><tag A="foo"/><tag B="bar"/></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
     def test_inorder_processing(self):
         src = '''<xml xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="foo" value="1.0"/>

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -858,6 +858,12 @@ class TestXacro(TestXacroCommentsIgnored):
 </a>
 ''')
 
+    def test_default_arg_empty(self):
+        self.assert_matches(self.quick_xacro('''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:arg name="foo" default=""/>$(arg foo)</a>'''),
+                            '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"/>''')
+
     def test_broken_input_doesnt_create_empty_output_file(self):
         # run xacro on broken input file to make sure we don't create an
         # empty output file

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1041,6 +1041,21 @@ class TestXacroInorder(TestXacro):
 <f val="42"/><f val="**"/></a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
+    def test_check_order_warning(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:property name="bar" value="unused"/>
+<xacro:property name="foo" value="unused"/>
+<xacro:macro name="foo" params="arg:=${foo}">
+    <a val="${arg}"/>
+</xacro:macro>
+<xacro:foo/>
+<xacro:property name="bar" value="dummy"/>
+<xacro:property name="foo" value="21"/></a>'''
+        with capture_stderr(self.quick_xacro, src, do_check_order=True) as (result, output):
+            self.assertTrue("Document is incompatible to --inorder processing." in output)
+            self.assertTrue("foo" in output)  # foo should be reported
+            self.assertTrue("bar" not in output)  # bar shouldn't be reported
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
These are my last commits to cleanup and finalize for a new release:
There are some new features:
- added `<xacro:attribute>` as discussed
- logging of property definitions and usage
- allow to export local macro properties to parent or global scope

``` xml
<xacro:property name="name" value="value" scope="parent | global"/>
```

There are some fixups:
- allow empty `<arg>` defaults
- fixed time of evaluation of a macro's default parameters

And finally some code cleanup:
- moved command line processing to cli.py
- moved xml processing to xmlutils.py + unified attribute processing
- deprecated `--oldorder` processing
- added --check-order option for compatibility test
