### PR TITLE
small fix

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -610,9 +610,6 @@ def handle_macro_call(node, name, macros, symbols):
             return handle_dynamic_macro_call(node, macros, symbols)
         return False
 
-    # Evaluate attribute and block parameters in node
-    eval_all(node, macros, symbols)  # for calling eval_all
-
     # Expand the macro
     scoped = Table(symbols)  # new local name space for macro evaluation
     params = m.params[:]  # deep copy macro's params list
@@ -620,7 +617,11 @@ def handle_macro_call(node, name, macros, symbols):
         if name not in params:
             raise XacroException("Invalid parameter \"%s\"" % str(name), macro=m)
         params.remove(name)
-        scoped[name] = value
+        scoped[name] = eval_text(value, symbols)
+        node.setAttribute(name, "")  # avoid second evaluation in eval_all()
+
+    # Evaluate block parameters in node
+    eval_all(node, macros, symbols)
 
     # Fetch block parameters, in order
     block = first_child_element(node)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -313,19 +313,6 @@ class TestXacro(TestXacroCommentsIgnored):
 '''
         self.assert_matches(self.quick_xacro(src), inOrder if self.in_order else oldOrder)
 
-    def test_DEPRECATED_should_replace_before_macroexpand(self):
-        self.assert_matches(
-                self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-<xacro:macro name="inner" params="*the_block">
-  <in_the_inner><xacro:insert_block name="the_block" /></in_the_inner>
-</xacro:macro>
-<xacro:macro name="outer" params="*the_block">
-  <in_the_outer><inner><xacro:insert_block name="the_block" /></inner></in_the_outer>
-</xacro:macro>
-<outer><woot /></outer></a>'''),
-                '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-<in_the_outer><in_the_inner><woot /></in_the_inner></in_the_outer></a>''')
-
     def test_should_replace_before_macroexpand(self):
         self.assert_matches(
                 self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -339,6 +339,12 @@ class TestXacro(TestXacroCommentsIgnored):
                 '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <in_the_outer><in_the_inner><woot /></in_the_inner></in_the_outer></a>''')
 
+    def test_evaluate_macro_params_before_body(self):
+        self.assert_matches(self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo" params="lst">${lst[-1]}</xacro:macro>
+  <foo lst="${[1,2,3]}"/></a>'''),
+        '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">3</a>''')
+
     def test_property_replacement(self):
         self.assert_matches(
                 self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">


### PR DESCRIPTION
Dear Morgan,

a colleague of mine found a small bug in the latest commits: When passing a complex python type (e.g. a list or dict) as macro parameter, it wasn't correctly passed, but converted to a string.

This PR fixes that issue. Sorry for bothering you again, just after creating the release.
