### PR TITLE
fix: correctly handle element names that are python keywords

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -610,7 +610,7 @@ def handle_macro_call(node, name, macros, symbols):
         #  to also resolve macros in namespaces, e.g. ns1.ns2.macro
         m = m or eval(name, dict(__builtins__={}), macros)
         body = m.body.cloneNode(deep=True)
-    except (NameError, TypeError):  # that wasn't a known macro
+    except:  # that wasn't a known macro
         # TODO If deprecation runs out, this test should be moved up front
         if node.tagName == 'xacro:call':
             return handle_dynamic_macro_call(node, macros, symbols)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -228,6 +228,10 @@ class TestXacro(TestXacroCommentsIgnored):
             self.assert_matches(result, res)
             self.assertTrue(output)
 
+    def test_special_element_names(self):
+        src = '''<a><in/></a>'''
+        self.assert_matches(self.quick_xacro(src), src)
+
     def test_invalid_property_name(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
         <xacro:property name="invalid.name"/></a>'''


### PR DESCRIPTION
An element `<in>` caused an exception, because namespaced macro-lookup
tried to resolve `in` as an identifier. Now all kinds of exceptions are catched during macro-lookup.

I'm afraid that some more corner cases, which I didn't yet consider will pop up.
Sorry, for seeing #97 late and thanks for fixing it (for me).
