### PR TITLE
property evaluation fixes

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -517,7 +517,16 @@ def grab_property(elt, table):
         name = '**' + name
         value = elt  # debug
 
-    if scope and scope == 'global': table = table.root()
+    if scope in ['global', 'parent']:
+        # ensure to evaluate within current context
+        # with (default) lazy evaluation, local vars will be gone at evaluation time
+        try:
+            value = eval_text(value, table)
+        except TypeError:
+            pass
+
+    if scope and scope == 'global':
+        table = table.root()
     if scope and scope == 'parent':
         if table.parent:
             table = table.parent

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1007,12 +1007,22 @@ class TestXacro(TestXacroCommentsIgnored):
         self.assert_matches(self.quick_xacro(src), res)
 
     def test_overwrite_globals(self):
-        src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
         <xacro:property name="pi"  value="3.14"/></a>'''
         with capture_stderr(self.quick_xacro, src) as (result, output):
             self.assert_matches(result, '<a xmlns:xacro="http://www.ros.org/wiki/xacro"/>')
             self.assertTrue(output)
 
+    def test_no_double_evaluation(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/xacro">
+  <xacro:macro name="foo" params="a b:=${a} c:=$${a}"> a=${a} b=${b} c=${c} </xacro:macro>
+  <xacro:property name="a" value="1"/>
+  <xacro:property name="d" value="$${a}"/>
+  <d d="${d}"><foo a="2"/></d>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/xacro"><d d="${a}"> a=2 b=1 c=${a} </d></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
 
 # test class for in-order processing
 class TestXacroInorder(TestXacro):

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -358,19 +358,21 @@ class TestXacro(TestXacroCommentsIgnored):
 
     def test_property_scope_parent(self):
         self.assert_matches(self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="foo"><xacro:property name="foo" value="42" scope="parent"/></xacro:macro>
-  <xacro:foo/><a foo="${foo}"/></a>'''),
+  <xacro:macro name="foo" params="factor">
+  <xacro:property name="foo" value="${21*factor}" scope="parent"/>
+  </xacro:macro>
+  <xacro:foo factor="2"/><a foo="${foo}"/></a>'''),
         '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><a foo="42"/></a>''')
 
     def test_property_scope_global(self):
         self.assert_matches(self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="foo">
+  <xacro:macro name="foo" params="factor">
     <xacro:macro name="bar">
-      <xacro:property name="foo" value="42" scope="global"/>
+      <xacro:property name="foo" value="${21*factor}" scope="global"/>
     </xacro:macro>
     <xacro:bar/>
   </xacro:macro>
-  <xacro:foo/><a foo="${foo}"/></a>'''),
+  <xacro:foo factor="2"/><a foo="${foo}"/></a>'''),
         '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><a foo="42"/></a>''')
 
     def test_math_ignores_spaces(self):


### PR DESCRIPTION
I noticed two issues with property evaluation:
- First, properties exported to the parent or global scope must not evaluated lazily, because at later evaluation time, the evaluation scope will have changed and eventually used variables will not be available anymore (or even worse have different values that are silently used instead). The first two commits handle this issue (fix + corresponding unittest).
- Lazy parameter evaluation of macros caused properties of type `$${foo}`, i.e. having escaped dollar signs, being evaluated multiple times, returning the evaluation result of `${foo}` instead of the plain string. This is fixed by the third commit (fix + unittest). This fix, allows to set a property without the lazy evaluation flag (that caused re-evaluation).
