### PR TITLE
forwarding macro arguments from outer scope

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -673,7 +673,15 @@ def handle_macro_call(node, macros, symbols):
 
     # Try to load defaults for any remaining non-block parameters
     for param in params[:]:
+        # block parameters are not supported for defaults
         if param[0] == '*': continue
+
+        # adopt existing property from outer scope
+        if param in symbols:
+            params.remove(param)
+            continue
+
+        # get default
         value = m.defaultmap.get(param, None)
         if value is not None:
             scoped._setitem(param, eval_text(value, symbols), unevaluated=False)

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -593,6 +593,24 @@ def eval_text(text, symbols):
         return ''.join(map(str, results))
 
 
+_forward_matcher = re.compile(r"^forward\((.*)\)$")
+def eval_default_arg(s, symbols, macro):
+    m = _forward_matcher.match(s)
+    if not m:
+        return eval_text(s, symbols)
+    args = m.group(1).split(',',1)
+    if len(args) not in [1, 2]:
+        raise XacroException("forward(property [,default]) requires one or two arguments")
+    name = args[0]
+    try:
+        return symbols[name]
+    except KeyError:
+        if len(args) == 2:
+            return eval_text(args[1], symbols)  # return default
+        else:
+            raise XacroException("Undefined property to forward: " + name, macro=macro)
+
+
 def handle_dynamic_macro_call(node, macros, symbols):
     name, = reqd_attrs(node, ['macro'])
     if not name:
@@ -676,15 +694,10 @@ def handle_macro_call(node, macros, symbols):
         # block parameters are not supported for defaults
         if param[0] == '*': continue
 
-        # adopt existing property from outer scope
-        if param in symbols:
-            params.remove(param)
-            continue
-
         # get default
         value = m.defaultmap.get(param, None)
         if value is not None:
-            scoped._setitem(param, eval_text(value, symbols), unevaluated=False)
+            scoped._setitem(param, eval_default_arg(value, symbols, m), unevaluated=False)
             params.remove(param)
 
     if params:

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -477,11 +477,11 @@ def parse_default_arg(param):
         return param[0], None  # no default arg at all
     name, default = param[0], param[1]
 
-    if not (default.startswith('$|') or default == '$'):
+    if not (default.startswith('^|') or default == '^'):
         return name, (None, default)  # simple default value
 
     # remove initial $| or $
-    default = default[2:] if default.startswith('$|') else default[1:]
+    default = default[2:] if default.startswith('^|') else default[1:]
     if not default:  # no fallback default
         return name, (name, None)
     else:

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -461,6 +461,26 @@ def is_valid_name(name):
     return False
 
 
+_forward_matcher = re.compile(r"^forward\((.*)\)$")
+def parse_default_arg(s):
+    """
+    parse a default argument spec for macro parameters
+    particularly handle forward(variable,default)
+    :param s: argument spec string
+    :return: pair of (variable, default), where any one may be None
+    """
+    m = _forward_matcher.match(s)
+    if not m:  # simple default value
+        return (None, s)
+    args = m.group(1).split(',',1)
+    if len(args) == 1:
+        return (args[0], None)
+    elif len(args) == 2:
+        return (args[0], args[1])
+    else:
+        raise XacroException("forward(property [,default]) requires one or two arguments")
+
+
 def grab_macro(elt, macros):
     assert(elt.tagName in ['macro', 'xacro:macro'])
     remove_previous_comments(elt)
@@ -484,7 +504,7 @@ def grab_macro(elt, macros):
         splitParam = param.split(':=')
 
         if len(splitParam) == 2:
-            defaultmap[splitParam[0]] = splitParam[1]  # parameter with default
+            defaultmap[splitParam[0]] = parse_default_arg(splitParam[1])  # parameter with default
             params[i] = splitParam[0]  # only keep the name
 
         elif len(splitParam) != 1:
@@ -593,22 +613,16 @@ def eval_text(text, symbols):
         return ''.join(map(str, results))
 
 
-_forward_matcher = re.compile(r"^forward\((.*)\)$")
-def eval_default_arg(s, symbols, macro):
-    m = _forward_matcher.match(s)
-    if not m:
-        return eval_text(s, symbols)
-    args = m.group(1).split(',',1)
-    if len(args) not in [1, 2]:
-        raise XacroException("forward(property [,default]) requires one or two arguments")
-    name = args[0]
+def eval_default_arg(forward_variable, default, symbols, macro):
+    if forward_variable is None:
+        return eval_text(default, symbols)
     try:
-        return symbols[name]
+        return symbols[forward_variable]
     except KeyError:
-        if len(args) == 2:
-            return eval_text(args[1], symbols)  # return default
+        if default is not None:
+            return eval_text(default, symbols)
         else:
-            raise XacroException("Undefined property to forward: " + name, macro=macro)
+            raise XacroException("Undefined property to forward: " + forward_variable, macro=macro)
 
 
 def handle_dynamic_macro_call(node, macros, symbols):
@@ -695,9 +709,9 @@ def handle_macro_call(node, macros, symbols):
         if param[0] == '*': continue
 
         # get default
-        value = m.defaultmap.get(param, None)
-        if value is not None:
-            scoped._setitem(param, eval_default_arg(value, symbols, m), unevaluated=False)
+        name, default = m.defaultmap.get(param, (None,None))
+        if name is not None or default is not None:
+            scoped._setitem(param, eval_default_arg(name, default, symbols, m), unevaluated=False)
             params.remove(param)
 
     if params:

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1027,7 +1027,7 @@ class TestXacro(TestXacroCommentsIgnored):
     def test_property_forwarding(self):
         src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
         <xacro:property name="arg" value="42"/>
-        <xacro:macro name="foo" params="arg:=$%s">${arg}</xacro:macro>
+        <xacro:macro name="foo" params="arg:=^%s">${arg}</xacro:macro>
         <xacro:foo/>
         </a>'''
         res='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">%s</a>'''

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1026,15 +1026,14 @@ class TestXacro(TestXacroCommentsIgnored):
 
     def test_property_forwarding(self):
         src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-        <xacro:property name="var" value="42"/>
-        <xacro:macro name="foo" params="arg:=forward(%s%s)">${arg}</xacro:macro>
+        <xacro:property name="arg" value="42"/>
+        <xacro:macro name="foo" params="arg:=$%s">${arg}</xacro:macro>
         <xacro:foo/>
         </a>'''
         res='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">%s</a>'''
-        self.assert_matches(self.quick_xacro(src % ('var', '')), res % '42')
-        self.assert_matches(self.quick_xacro(src % ('var', ',6')), res % '42')
-        self.assert_matches(self.quick_xacro(src % ('undefined', ',${2*(1+2)}')), res % '6')
-        self.assertRaises(xacro.XacroException, self.quick_xacro, src % ('undefined', ''))
+        self.assert_matches(self.quick_xacro(src % ''), res % '42')
+        self.assert_matches(self.quick_xacro(src % '|'), res % '42')
+        self.assert_matches(self.quick_xacro(src % '|6'), res % '42')
 
 
 # test class for in-order processing

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1024,6 +1024,19 @@ class TestXacro(TestXacroCommentsIgnored):
         res = '''<a xmlns:xacro="http://www.ros.org/xacro"><d d="${a}"> a=2 b=1 c=${a} </d></a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
+    def test_property_forwarding(self):
+        src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+        <xacro:property name="var" value="42"/>
+        <xacro:macro name="foo" params="arg:=forward(%s%s)">${arg}</xacro:macro>
+        <xacro:foo/>
+        </a>'''
+        res='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">%s</a>'''
+        self.assert_matches(self.quick_xacro(src % ('var', '')), res % '42')
+        self.assert_matches(self.quick_xacro(src % ('var', ',6')), res % '42')
+        self.assert_matches(self.quick_xacro(src % ('undefined', ',${2*(1+2)}')), res % '6')
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src % ('undefined', ''))
+
+
 # test class for in-order processing
 class TestXacroInorder(TestXacro):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Implementation of #100 using the finally agreed-on syntax:

``` xml
<xacro:macro name="foo" params="p1 p2:=a p3:=^ p4:=^|b">
```

to auto-forward properties existing in outer scope to macro scrope. The caret `^` indicates to use the outer-scope property (with same name). The pipe `|` indicates to use the given fallback if the property is not defined.
