### PR TITLE
fix #108: evaluate property blocks recursively too

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -595,7 +595,10 @@ def eval_all(node, macros, symbols):
                     raise XacroException("Undefined block \"%s\"" % name)
 
                 # cloning block allows to insert the same block multiple times
-                replace_node(node, by=block.cloneNode(deep=True), content_only=content_only)
+                block = block.cloneNode(deep=True)
+                # recursively evaluate block
+                eval_all(block, macros, symbols)
+                replace_node(node, by=block, content_only=content_only)
 
             elif is_include(node):
                 process_include(node, symbols, lambda doc: eval_all(doc, macros, symbols))

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -380,15 +380,17 @@ class TestXacro(TestXacroCommentsIgnored):
     def test_insert_block_property(self):
         self.assert_matches(
                 self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:macro name="bar">bar</xacro:macro>
+<xacro:property name="val" value="2" />
 <xacro:property name="some_block">
-  <some_block />
+  <some_block attr="${val}"><xacro:bar/></some_block>
 </xacro:property>
 <foo>
   <xacro:insert_block name="some_block" />
 </foo>
 </a>'''),
                 '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-<foo><some_block /></foo>
+<foo><some_block attr="2">bar</some_block></foo>
 </a>''')
 
     def test_include(self):


### PR DESCRIPTION
When switching to recursive eval_all(), I forgot to recursively evaluate the inserted block. Fixed now.
Extended the appropriate unittest to also include a property and macro definition.
