### PR TITLE
use correct catkin environment for cmake dependency checking

### DIFF
--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -84,7 +84,7 @@ function(xacro_add_xacro_file input)
 
   ## Call out to xacro to determine dependencies
   message(STATUS "xacro: determining deps for: " ${input} " ...")
-  execute_process(COMMAND ${_xacro_py} ${_XACRO_INORDER} --deps ${input} ${_XACRO_REMAP}
+  execute_process(COMMAND ${CATKIN_ENV} ${_xacro_py} ${_XACRO_INORDER} --deps ${input} ${_XACRO_REMAP}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     ERROR_VARIABLE _xacro_err
     OUTPUT_VARIABLE _xacro_deps_result


### PR DESCRIPTION
Both, the final and the dependency-checking xacro calls, should
be executed within the correct catkin environment. Otherwise different
xacro versions might be used for both steps.
