### PR TITLE
load_yaml now has an optional package parameter for the yaml file

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -38,6 +38,7 @@ import re
 import sys
 import ast
 import math
+import rospkg
 
 from roslaunch import substitution_args
 from rospkg.common import ResourceNotFound
@@ -89,13 +90,16 @@ def abs_filename_spec(filename_spec):
     return filename_spec
 
 
-def load_yaml(filename):
+def load_yaml(filename, package=None):
     try:
         import yaml
     except:
         raise XacroException("yaml support not available; install python-yaml")
 
-    filename = abs_filename_spec(filename)
+    if(package is None):
+        filename = abs_filename_spec(filename)
+    else:
+        filename = rospkg.RosPack().get_path(package) + "/" + filename
     f = open(filename)
     oldstack = push_file(filename)
     try:


### PR DESCRIPTION
Before, the yaml file loaded with load_yaml had to be in the same directory as the xacro file in which it appeared. In my use case, I have a file that needs to load a yaml file in a different package. As load_yaml was already using the ${} special command notation, I could not use a ${find package} inside of it. This might not be the best way to implement this feature, but it works and it doesn't seem to break existing stuff.

Disclaimer: I'm no python dev...
