### PR TITLE
allow (one-level) nested expression/extension evaluation

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -584,14 +584,14 @@ LEXER = QuickLexer(DOLLAR_DOLLAR_BRACE=r"\$\$+\{",
 def eval_text(text, symbols):
     def handle_expr(s):
         try:
-            return eval(s, global_symbols, symbols)
+            return eval(eval_text(s, symbols), global_symbols, symbols)
         except Exception as e:
             # re-raise as XacroException to add more context
             raise XacroException(exc=e,
                 suffix=os.linesep + "when evaluating expression '%s'" % s)
 
     def handle_extension(s):
-        return eval_extension("$(%s)" % s)
+        return eval_extension("$(%s)" % eval_text(s, symbols))
 
     results = []
     lex = QuickLexer(LEXER)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1062,6 +1062,15 @@ class TestXacro(TestXacroCommentsIgnored):
         self.assert_matches(self.quick_xacro(src % '|'), res % '42')
         self.assert_matches(self.quick_xacro(src % '|6'), res % '42')
 
+    def test_extension_in_expression(self):
+        src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">${2*'$(arg var)'}</a>'''
+        res='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">%s</a>'''
+        self.assert_matches(self.quick_xacro(src, ['var:=xacro']), res % (2*'xacro'))
+
+    def test_expression_in_extension(self):
+        src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">$(arg ${'v'+'ar'})</a>'''
+        res='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">%s</a>'''
+        self.assert_matches(self.quick_xacro(src, ['var:=xacro']), res % 'xacro')
 
 # test class for in-order processing
 class TestXacroInorder(TestXacro):


### PR DESCRIPTION
This is a simple solution for #113 to allow for simple, one-level, nested evaluation of `${}` and `$()` expressions.

As the `QuickLexer` searches for the next closing parentheses, deeper nesting is not possible.
However, so far I only observed the need for one-level nesting which is exactly provided by this hack.
