### PR TITLE
Unicode processing

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -47,10 +47,11 @@ from .xmlutils import *
 from .cli import process_args
 
 
-try:
+try: # python 2
     _basestr = basestring
-except NameError:
-    _basestr = unicode
+except NameError: # python 3
+    _basestr = str
+    unicode = str
 
 # Dictionary of substitution args
 substitution_args_context = {}

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -50,7 +50,7 @@ from .cli import process_args
 try:
     _basestr = basestring
 except NameError:
-    _basestr = str
+    _basestr = unicode
 
 # Dictionary of substitution args
 substitution_args_context = {}
@@ -129,7 +129,7 @@ class XacroException(Exception):
         self.macros = [] if macro is None else [macro]
 
     def __str__(self):
-        return ' '.join([str(item) for item in
+        return ' '.join([unicode(item) for item in
                          [self.message, self.exc, self.suffix] if item])
 
 
@@ -273,10 +273,10 @@ class Table(object):
             (self.parent and key in self.parent)
 
     def __str__(self):
-        s = str(self.table)
+        s = unicode(self.table)
         if isinstance(self.parent, Table):
             s += "\n  parent: "
-            s += str(self.parent)
+            s += unicode(self.parent)
         return s
 
     def root(self):
@@ -613,7 +613,7 @@ def eval_text(text, symbols):
         return results[0]
     # otherwise join elements to a string
     else:
-        return ''.join(map(str, results))
+        return ''.join(map(unicode, results))
 
 
 def eval_default_arg(forward_variable, default, symbols, macro):
@@ -632,7 +632,7 @@ def handle_dynamic_macro_call(node, macros, symbols):
     name, = reqd_attrs(node, ['macro'])
     if not name:
         raise XacroException("xacro:call is missing the 'macro' attribute")
-    name = str(eval_text(name, symbols))
+    name = unicode(eval_text(name, symbols))
 
     # remove 'macro' attribute and rename tag with resolved macro name
     node.removeAttribute('macro')
@@ -685,7 +685,7 @@ def handle_macro_call(node, macros, symbols):
     params = m.params[:]  # deep copy macro's params list
     for name, value in node.attributes.items():
         if name not in params:
-            raise XacroException("Invalid parameter \"%s\"" % str(name), macro=m)
+            raise XacroException("Invalid parameter \"%s\"" % unicode(name), macro=m)
         params.remove(name)
         scoped._setitem(name, eval_text(value, symbols), unevaluated=False)
         node.setAttribute(name, "")  # suppress second evaluation in eval_all()
@@ -785,7 +785,7 @@ def eval_all(node, macros, symbols):
     """Recursively evaluate node, expanding macros, replacing properties, and evaluating expressions"""
     # evaluate the attributes
     for name, value in node.attributes.items():
-        result = str(eval_text(value, symbols))
+        result = unicode(eval_text(value, symbols))
         node.setAttribute(name, result)
 
     node = node.firstChild
@@ -876,7 +876,7 @@ def eval_all(node, macros, symbols):
 
         # TODO: Also evaluate content of COMMENT_NODEs?
         elif node.nodeType == xml.dom.Node.TEXT_NODE:
-            node.data = str(eval_text(node.data, symbols))
+            node.data = unicode(eval_text(node.data, symbols))
 
         node = next
 
@@ -1024,7 +1024,7 @@ def main():
 
     # error handling
     except xml.parsers.expat.ExpatError as e:
-        error("XML parsing error: %s" % str(e), alt_text=None)
+        error("XML parsing error: %s" % unicode(e), alt_text=None)
         if verbosity > 0:
             print_location(filestack, e)
             print(file=sys.stderr) # add empty separator line before error
@@ -1035,7 +1035,7 @@ def main():
         sys.exit(2)  # indicate failure, but don't print stack trace on XML errors
 
     except Exception as e:
-        error(str(e))
+        error(unicode(e))
         if verbosity > 0:
             print_location(filestack, e)
         if verbosity > 1:
@@ -1051,7 +1051,7 @@ def main():
         return
 
     # write output
-    out.write(doc.toprettyxml(indent='  '))
+    out.write(doc.toprettyxml(indent='  ').encode('utf8'))
     print()
     # only close output file, but not stdout
     if opts.output:

--- a/test/emoji.xacro
+++ b/test/emoji.xacro
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="burger" value="🍔" />
+  ${burger}
+</robot>

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1135,9 +1135,66 @@ class TestXacroInorder(TestXacro):
             self.assertTrue("foo" in output)  # foo should be reported
             self.assertTrue("bar" not in output)  # bar shouldn't be reported
 
-    def test_extended_character_parsing(self):
+    def test_unicode_literal_parsing(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">🍔 </a>'''
         self.assert_matches(self.quick_xacro(src), src)
+
+    def test_unicode_property(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:property name="burger" value="🍔"/>
+${burger}</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">🍔</a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_unicode_property_attribute(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:property name="burger" value="🍔"/>
+<b c="${burger}"/></a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><b c="🍔"/></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_unicode_property_block(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:property name="burger">
+🍔
+</xacro:property>
+<xacro:insert_block name="burger"/></a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">🍔</a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_unicode_conditional(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:property name="burger" value="🍔"/>
+<xacro:if value="${burger == u'🍔'}">
+🍟
+</xacro:if>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">🍟</a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_unicode_macro(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:macro name="burger" params="how_many">
+${u'🍔' * how_many}
+</xacro:macro>
+<xacro:burger how_many="4"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+🍔🍔🍔🍔</a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_unicode_file(self):
+        # run the full xacro processing pipeline on a file with
+        # unicode characters in it and make sure the output is correct
+        test_dir= os.path.abspath(os.path.dirname(__file__))
+        input_path = os.path.join(test_dir, 'emoji.xacro')
+        tmp_dir_name = tempfile.mkdtemp() # create directory we can trash
+        output_path = os.path.join(tmp_dir_name, "out.xml")
+        self.run_xacro(input_path, '-o', output_path)
+        output_file_created = os.path.isfile(output_path)
+        self.assert_matches(xml.dom.minidom.parse(output_path),
+            '''<robot xmlns:xacro="http://ros.org/wiki/xacro">🍔</robot>''')
+        shutil.rmtree(tmp_dir_name) # clean up after ourselves
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 
@@ -1134,6 +1135,9 @@ class TestXacroInorder(TestXacro):
             self.assertTrue("foo" in output)  # foo should be reported
             self.assertTrue("bar" not in output)  # bar shouldn't be reported
 
+    def test_extended_character_parsing(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">🍔 </a>'''
+        self.assert_matches(self.quick_xacro(src), src)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR attempts to permit at least some level of Unicode characters in xacro. Since xacro property and macro names eventually become Python identifiers, those strings are restricted to ASCII (like Python identifiers), but the rest of the content should now allow Unicode, as was requested in #69 . Feedback appreciated though; it's quite possible I missed some code paths, and I'm sure there is a better way to do some of these things.
