### PR TITLE
Fix file check for python3.

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -902,7 +902,7 @@ def parse(inp, filename=None):
     try:
         if isinstance(inp, _basestr):
             return xml.dom.minidom.parseString(inp)
-        elif isinstance(inp, file):
+        elif hasattr(inp, 'read'):
             return xml.dom.minidom.parse(inp)
         return inp
 


### PR DESCRIPTION
Running xacro on arch with Python 3.5 I got the following error :

NameError: name 'file' is not defined

'file' is no longer defined in python3, comparing it to io.IOBase should work according to http://stackoverflow.com/questions/18880948/python-3-3-2-check-that-object-is-of-type-file
