### PR TITLE
Add debug option.

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -34,6 +34,7 @@ from __future__ import print_function
 
 import getopt
 import glob
+import logging
 import os
 import re
 import string
@@ -342,6 +343,7 @@ def grab_properties(doc):
                                  '"{", "}", or "$" : "' + name + '"')
             else:
                 table[name] = value
+                logging.debug('name={}, val={}'.format(name, table[name]))
 
             elt.parentNode.removeChild(elt)
             elt = None
@@ -645,11 +647,12 @@ def open_output(output_filename):
 
 def main():
     try:
-        opts, args = getopt.gnu_getopt(sys.argv[1:], "ho:", ['deps', 'includes'])
+        opts, args = getopt.gnu_getopt(sys.argv[1:], "ho:", ['debug', 'deps', 'includes'])
     except getopt.GetoptError as err:
         print(str(err))
         print_usage(2)
 
+    debug_mode = False
     just_deps = False
     just_includes = False
 
@@ -659,6 +662,8 @@ def main():
             print_usage(0)
         elif o == '-o':
             output_filename = a
+        elif o == '--debug':
+            debug_mode = True
         elif o == '--deps':
             just_deps = True
         elif o == '--includes':
@@ -671,6 +676,12 @@ def main():
     # Process substitution args
     set_substitution_args_context(load_mappings(sys.argv))
 
+    if debug_mode:
+        logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+    else:
+        logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+    logging.debug('Input xacro file full path={}'.format(args[0]))
     f = open(args[0])
     doc = None
     try:

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -678,3 +678,12 @@ class TestXacro(unittest.TestCase):
   </joint>
 </robot>'''))
 
+    def test_debugmode(self):
+        '''
+        Debug mode of xacro.py only prints some info and may not really be test-able, so
+        in this test we just test if debug mode does not cause any error.
+        '''
+        test_dir = os.path.abspath(os.path.dirname(__file__))
+        xacro_path = os.path.join(test_dir, '..', 'xacro.py')
+        broken_file_path = os.path.join(test_dir, 'broken.xacro')  # Whatever input is fine. 
+        self.assertEqual(subprocess.call([xacro_path, broken_file_path, '--debug']), 1)


### PR DESCRIPTION
Undefined property error is hard to debug without knowing which properties are read / are not read. So I'm adding debug feature.

```
rosrun xacro xacro foo.xacro --debug

2016-07-20 17:57:34,024 - DEBUG - Input xacro file full path=/home/roslinguini/src/sirobot1_gazebo/model/foo.xacro
2016-07-20 17:57:34,119 - DEBUG - name=pi, val=3.1415926535897931
2016-07-20 17:57:34,119 - DEBUG - name=small_mass, val=0.001
2016-07-20 17:57:34,120 - DEBUG - name=pi, val=3.1415926535897931
2016-07-20 17:57:34,120 - DEBUG - name=pi, val=3.1415926535897931
2016-07-20 17:57:34,120 - DEBUG - name=width_shelf, val=0.005
2016-07-20 17:57:34,120 - DEBUG - name=radius, val=0.002
2016-07-20 17:57:34,120 - DEBUG - name=pi, val=3.1415926535897931
2016-07-20 17:57:34,120 - DEBUG - name=pi, val=3.1415926535897931
2016-07-20 17:57:34,121 - DEBUG - name=wheel_mass, val=0.5
2016-07-20 17:57:34,121 - DEBUG - name=sphere_mass, val=0.3
```
