### PR TITLE
Convert exception to string in a python2/3 compatible way.

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -129,8 +129,8 @@ class XacroException(Exception):
         self.macros = [] if macro is None else [macro]
 
     def __str__(self):
-        return ' '.join([str(item) for item in
-                         [self.message, self.exc, self.suffix] if item])
+        items = [super(XacroException, self).__str__(), self.exc, self.suffix]
+        return ' '.join([str(e) for e in items if e])
 
 
 verbosity = 1


### PR DESCRIPTION
In python3, `Exception` doesn't have a `message` attribute anymore. The proper way to convert exceptions to strings is just to call `str` on them (works for both python 2 and 3). We can't do that directly here, because we want to to use the string conversion method of the parent class. We can still do that with `super()` though. So that is what this PR does.

Without it, the exception handler crashes without printing the wanted message.