### PR TITLE
Add option to generate files with .urdf suffix

### DIFF
--- a/cmake/xacro-extras.cmake.em
+++ b/cmake/xacro-extras.cmake.em
@@ -36,7 +36,7 @@ add_custom_target(${PROJECT_NAME}_xacro_generated_to_devel_space_ ALL)
 ##                 TARGET xacro_target INSTALL DESTINATION xml)
 function(xacro_add_xacro_file input)
   # parse arguments
-  set(options INORDER)
+  set(options INORDER URDF_EXTENSION)
   set(oneValueArgs OUTPUT)
   set(multiValueArgs REMAP)
   cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -60,6 +60,11 @@ function(xacro_add_xacro_file input)
     endif()
   endif()
   # message(STATUS "output: ${output}")
+
+  # append .urdf suffix if required
+  if(_XACRO_URDF_EXTENSION)
+    set(output "${output}.urdf")
+  endif()
 
   # transform _XACRO_INORDER's BOOL value
   if(_XACRO_INORDER)
@@ -157,7 +162,7 @@ endfunction(xacro_install)
 ## in devel and install space.
 function(xacro_add_files)
   # parse arguments
-  set(options INORDER INSTALL)
+  set(options INORDER INSTALL URDF_EXTENSION)
   set(oneValueArgs OUTPUT TARGET DESTINATION)
   set(multiValueArgs REMAP)
   cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -175,6 +180,13 @@ function(xacro_add_files)
     set(_XACRO_REMAP REMAP ${_XACRO_REMAP})
   endif()
 
+  # transform _XACRO_URDF_EXTENSION's BOOL value
+  if(_XACRO_URDF_EXTENSION)
+    set(_XACRO_URDF_EXTENSION "URDF_EXTENSION")
+  else()
+    unset(_XACRO_URDF_EXTENSION)
+  endif()
+
   # have INSTALL option, but no TARGET: fallback to default target
   if(_XACRO_INSTALL AND NOT _XACRO_TARGET)
     # message(STATUS "xacro: no TARGET specified, using default")
@@ -183,7 +195,7 @@ function(xacro_add_files)
 
   foreach(input ${_XACRO_UNPARSED_ARGUMENTS})
     # call to main function
-    xacro_add_xacro_file(${input} ${_XACRO_OUTPUT} ${_XACRO_INORDER} ${_XACRO_REMAP})
+    xacro_add_xacro_file(${input} ${_XACRO_OUTPUT} ${_XACRO_INORDER} ${_XACRO_URDF_EXTENSION} ${_XACRO_REMAP})
     list(APPEND outputs ${XACRO_OUTPUT_FILE})
   endforeach()
 


### PR DESCRIPTION
Currently the generated files do not have an extension at all, I think it would be nice to be able to add the extension automatically.

This new option allows to generate files with the URDF extension.

Example:


```cmake
set(
  xacro_files
  ${CMAKE_CURRENT_SOURCE_DIR}/urdf/robot_1.xacro
  ${CMAKE_CURRENT_SOURCE_DIR}/urdf/robot_2.xacro
  )

xacro_add_files(
  ${xacro_files}
  INORDER
  URDF_EXTENSION
  TARGET
  xacro_target
  INSTALL
  DESTINATION
  urdf
)
```


```bash
$ catkin_make install
Base path: /home/victor/code/catkin_workspace
Source space: /home/victor/code/catkin_workspace/src
Build space: /home/victor/code/catkin_workspace/build
Devel space: /home/victor/code/catkin_workspace/devel
Install space: /home/victor/code/catkin_workspace/install
####
#### Running command: "cmake /home/victor/code/catkin_workspace/src -DCATKIN_DEVEL_PREFIX=/home/victor/code/catkin_workspace/devel -DCMAKE_INSTALL_PREFIX=/home/victor/code/catkin_workspace/install -G Unix Makefiles" in "/home/victor/code/catkin_workspace/build"
####
-- The C compiler identification is GNU 6.2.0
-- The CXX compiler identification is GNU 6.2.0
-- Check for working C compiler: /usr/lib/ccache/cc
-- Check for working C compiler: /usr/lib/ccache/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/lib/ccache/c++
-- Check for working CXX compiler: /usr/lib/ccache/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/victor/code/catkin_workspace/devel
-- Using CMAKE_PREFIX_PATH: /opt/ros/kinetic
-- This workspace overlays: /opt/ros/kinetic
-- Found PythonInterp: /usr/bin/python (found version "2.7.12") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /media/victor/Data/code/catkin_workspace/build/test_results
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found gtest sources under '/usr/src/gtest': gtests will be built
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.6
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 1 packages in topological order:
-- ~~  - xacro_urdf_cmake
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin package: 'xacro_urdf_cmake'
-- ==> add_subdirectory(xacro_urdf_cmake)
-- xacro: determining deps for: /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_1.xacro ...
-- xacro: determining deps for: /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_2.xacro ...
-- Configuring done
-- Generating done
-- Build files have been written to: /media/victor/Data/code/catkin_workspace/build
####
#### Running command: "make install -j4 -l4" in "/home/victor/code/catkin_workspace/build"
####
Scanning dependencies of target xacro_urdf_cmake_xacro_target
Scanning dependencies of target xacro_urdf_cmake_xacro_target_to_devel_space_
[ 14%] xacro: generating /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_2.urdf from /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_2.xacro
[ 28%] xacro: generating /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_1.urdf from /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_1.xacro
[ 42%] creating dir /home/victor/code/catkin_workspace/devel/share/xacro_urdf_cmake/urdf
[ 57%] xacro: generating /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_1.urdf from /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_1.xacro
[ 71%] xacro: generating /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_2.urdf from /home/victor/code/catkin_workspace/src/xacro_urdf_cmake/urdf/robot_2.xacro
[ 85%] Copying to devel space: /home/victor/code/catkin_workspace/devel/share/xacro_urdf_cmake/urdf/robot_2.urdf
[ 85%] Built target xacro_urdf_cmake_xacro_target
[100%] Copying to devel space: /home/victor/code/catkin_workspace/devel/share/xacro_urdf_cmake/urdf/robot_1.urdf
[100%] Built target xacro_urdf_cmake_xacro_target_to_devel_space_
Scanning dependencies of target xacro_urdf_cmake_xacro_generated_to_devel_space_
[100%] Built target xacro_urdf_cmake_xacro_generated_to_devel_space_
Install the project...
-- Install configuration: ""
-- Installing: /home/victor/code/catkin_workspace/install/_setup_util.py
-- Installing: /home/victor/code/catkin_workspace/install/env.sh
-- Installing: /home/victor/code/catkin_workspace/install/setup.bash
-- Installing: /home/victor/code/catkin_workspace/install/setup.sh
-- Installing: /home/victor/code/catkin_workspace/install/setup.zsh
-- Installing: /home/victor/code/catkin_workspace/install/.rosinstall
-- Installing: /home/victor/code/catkin_workspace/install/lib/pkgconfig/xacro_urdf_cmake.pc
-- Installing: /home/victor/code/catkin_workspace/install/share/xacro_urdf_cmake/cmake/xacro_urdf_cmakeConfig.cmake
-- Installing: /home/victor/code/catkin_workspace/install/share/xacro_urdf_cmake/cmake/xacro_urdf_cmakeConfig-version.cmake
-- Installing: /home/victor/code/catkin_workspace/install/share/xacro_urdf_cmake/package.xml
-- Installing: /home/victor/code/catkin_workspace/install/share/xacro_urdf_cmake/urdf/robot_1.urdf
-- Installing: /home/victor/code/catkin_workspace/install/share/xacro_urdf_cmake/urdf/robot_2.urdf

```