### PR TITLE
True/False literals in expressions

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -109,7 +109,7 @@ def load_yaml(filename):
 # taking simple security measures to forbid access to __builtins__
 # only the very few symbols explicitly listed are allowed
 # for discussion, see: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int']}}
+global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int', 'True', 'False']}}
 # also define all math symbols and functions
 global_symbols.update(math.__dict__)
 # allow to import dicts from yaml

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -607,6 +607,21 @@ class TestXacro(TestXacroCommentsIgnored):
     <b />
 </robot>''')
 
+    def test_boolean_if_statement(self):
+        self.assert_matches(
+                self.quick_xacro('''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="condT" value="${True}"/>
+  <xacro:property name="condF" value="${False}"/>
+  <xacro:if value="${condF}"><a /></xacro:if>
+  <xacro:if value="${condT}"><b /></xacro:if>
+  <xacro:if value="${True}"><c /></xacro:if>
+</robot>'''),
+                '''\
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <b /><c />
+</robot>''')
+
     def test_consecutive_if(self):
         self.assert_matches(self.quick_xacro('''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">


### PR DESCRIPTION
As indicated in #145, python's True / False literals are not correctly forwarded to xacro, which doesn't allow for the following xacro code:
```
<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
  <xacro:property name="cond" value="${True}"/>
  <xacro:if value="${cond}"><enabled/></xacro:if>
</robot>
```
This PR adds True/False to the list of available python keywords in `${}` expressions.