### PR TITLE
fixes for #148 and #149

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -1011,7 +1011,7 @@ def process_file(input_file_name, **kwargs):
 
 def main():
     opts, input_file_name = process_args(sys.argv[1:])
-    if opts.in_order == False:
+    if opts.in_order == False and not opts.just_includes:
         warning("xacro: Traditional processing is deprecated. Switch to --inorder processing!")
         message("To check for compatibility of your document, use option --check-order.", color='yellow')
         message("For more infos, see http://wiki.ros.org/xacro#Processing_Order", color='yellow')

--- a/src/xacro/cli.py
+++ b/src/xacro/cli.py
@@ -100,6 +100,8 @@ def process_args(argv, require_input=True):
     filtered_args = [a for a in argv if REMAP not in a]  # filter-out REMAP args
     (options, pos_args) = parser.parse_args(filtered_args)
 
+    # --inorder is incompatible to --includes: --inorder processing starts evaluation
+    # while --includes should return the unmodified document
     if options.in_order and options.just_includes:
         parser.error("options --inorder and --includes are mutually exclusive")
 

--- a/src/xacro/xmlutils.py
+++ b/src/xacro/xmlutils.py
@@ -118,7 +118,7 @@ def check_attrs(tag, required, optional):
     result = reqd_attrs(tag, required)
     result.extend(opt_attrs(tag, optional))
     allowed = required + optional
-    extra = [a for a in tag.attributes.keys() if a not in allowed]
+    extra = [a for a in tag.attributes.keys() if a not in allowed and not a.startswith("xmlns:")]
     if extra:
         warning("%s: unknown attribute(s): %s" % (tag.nodeName, ', '.join(extra)))
     return result


### PR DESCRIPTION
Fixes #148 and #149:
- suppress warning about extra attributes that are namespace specifiers
- suppress `--inorder` deprecation warning when `--includes` option is given