### PR TITLE
Small fixes to make it work with Python 3

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -950,7 +950,7 @@ def process_doc(doc,
     if do_check_order and symbols.redefined:
         warning("Document is incompatible to --inorder processing.")
         warning("The following properties were redefined after usage:")
-        for k, v in symbols.redefined.iteritems():
+        for k, v in symbols.redefined.items():
             message(k, "redefined in", v, color='yellow')
 
 

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -203,17 +203,13 @@ class Table(object):
     @staticmethod
     def _eval_literal(value):
         if isinstance(value, _basestr):
-            try:
-                # try to evaluate as literal, e.g. number, boolean, etc.
-                # this is needed to handle numbers in property definitions as numbers, not strings
-                evaluated = ast.literal_eval(value.strip())
-                # However, (simple) list, tuple, dict expressions will be evaluated as such too,
-                # which would break expected behaviour. Thus we only accept the evaluation otherwise.
-                if not isinstance(evaluated, (list, dict, tuple)):
-                    return evaluated
-            except:
-                pass
-
+            # try to evaluate as number literal or boolean
+            # this is needed to handle numbers in property definitions as numbers, not strings
+            for f in [int, float, lambda x: get_boolean_value(x, None)]: # order of types is important!
+                try:
+                    return f(value)
+                except:
+                    pass
         return value
 
     def _resolve_(self, key):
@@ -750,9 +746,9 @@ def get_boolean_value(value, condition):
     """
     try:
         if isinstance(value, _basestr):
-            if value == 'true': return True
-            elif value == 'false': return False
-            else: return ast.literal_eval(value)
+            if value == 'true' or value == 'True': return True
+            elif value == 'false' or value == 'False': return False
+            else: return bool(int(value))
         else:
             return bool(value)
     except:

--- a/src/xacro/xmlutils.py
+++ b/src/xacro/xmlutils.py
@@ -30,7 +30,6 @@
 # Authors: Stuart Glaser, William Woodall, Robert Haschke
 # Maintainer: Morgan Quigley <morgan@osrfoundation.org>
 
-import xml
 import xml.dom.minidom
 from .color import warning
 

--- a/src/xacro/xmlutils.py
+++ b/src/xacro/xmlutils.py
@@ -31,6 +31,7 @@
 # Maintainer: Morgan Quigley <morgan@osrfoundation.org>
 
 import xml
+import xml.dom.minidom
 from .color import warning
 
 def first_child_element(elt):

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -978,7 +978,7 @@ class TestXacro(TestXacroCommentsIgnored):
   <a list="${list}" tuple="${tuple}" dict="${dic}"/>
 </a>'''),
 '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <a list="[0, 2, 2]" tuple="(0, 2, 2)" dict="{'a': 0, 'c': 2, 'b': 2}"/>
+  <a list="[0, 2, 2]" tuple="(0, 2, 2)" dict="''' +str({'a': 0, 'c': 2, 'b': 2}) + '''"/>
 </a>''')
 
     def test_enforce_xacro_ns(self):

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -12,7 +12,10 @@ import tempfile
 import shutil
 import subprocess
 import re
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO # Python 2.x
+except ImportError:
+    from io import StringIO # Python 3.x
 from contextlib import contextmanager
 
 
@@ -167,8 +170,8 @@ class TestXacroFunctions(unittest.TestCase):
     def test_resolve_macro(self):
         # define three nested macro dicts with the same macro names (keys)
         content = {'xacro:simple': 'simple'}
-        ns2 = dict({k: v+'2' for k,v in content.iteritems()})
-        ns1 = dict({k: v+'1' for k,v in content.iteritems()})
+        ns2 = dict({k: v+'2' for k,v in content.items()})
+        ns1 = dict({k: v+'1' for k,v in content.items()})
         ns1.update(ns2=ns2)
         macros = dict(content)
         macros.update(ns1=ns1)

--- a/xacro.py
+++ b/xacro.py
@@ -50,7 +50,7 @@ os.chdir(this_dir)
 this_dir_cwd = os.getcwd()
 os.chdir(cur_dir)
 # Remove this dir from path
-sys.path = filter(lambda a: a not in [this_dir, this_dir_cwd], sys.path)
+sys.path = [a for a in sys.path if a not in [this_dir, this_dir_cwd]]
 
 import xacro
 from xacro.color import warning


### PR DESCRIPTION
Note that two tests fail due to internal changes in Python 3:
- test_iterable_literals_eval: The order of keys in dict changed in Py3
- test_no_evaluation: ast.literal_eval('5 -2') gives 3 in Py3