### PR TITLE
optional loading of ROS-related packages

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -39,8 +39,6 @@ import sys
 import ast
 import math
 
-from roslaunch import substitution_args
-from rospkg.common import ResourceNotFound
 from copy import deepcopy
 from .color import warning, error, message
 from .xmlutils import *
@@ -179,7 +177,11 @@ def eval_extension(s):
     if s == '$(cwd)':
         return os.getcwd()
     try:
+        from roslaunch import substitution_args
+        from rospkg.common import ResourceNotFound
         return substitution_args.resolve_args(s, context=substitution_args_context, resolve_anon=False)
+    except ImportError as e:
+        raise XacroException("substitution args not supported: ", exc=e)
     except substitution_args.ArgException as e:
         raise XacroException("Undefined substitution argument", exc=e)
     except ResourceNotFound as e:

--- a/src/xacro/cli.py
+++ b/src/xacro/cli.py
@@ -32,8 +32,7 @@
 
 import textwrap
 from optparse import OptionParser, IndentedHelpFormatter
-from rosgraph.names import load_mappings, REMAP
-from .color import colorize
+from .color import colorize, warning
 
 class ColoredOptionParser(OptionParser):
     def error(self, message):
@@ -93,11 +92,17 @@ def process_args(argv, require_input=True):
                       4: log property definitions and usage on all levels"""))
 
     # process substitution args
-    mappings = load_mappings(argv)
+    try:
+        from rosgraph.names import load_mappings, REMAP
+        mappings = load_mappings(argv)
+        filtered_args = [a for a in argv if REMAP not in a]  # filter-out REMAP args
+    except ImportError as e:
+        warning(e)
+        mappings = {}
+        filtered_args = argv
 
     parser.set_defaults(in_order=False, just_deps=False, just_includes=False,
                         verbosity=1)
-    filtered_args = [a for a in argv if REMAP not in a]  # filter-out REMAP args
     (options, pos_args) = parser.parse_args(filtered_args)
 
     if options.in_order and options.just_includes:


### PR DESCRIPTION
To broaden xacro's usability domain, import ROS-related packages optionally only, disabling associated features like substitution_args and remapping in this case. Thus, xacro can be used without a ROS environment.
This is somehow related to #154 because ROS2 cannot yet provide all substitution args too.