### PR TITLE
Python macros

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -38,6 +38,7 @@ import re
 import sys
 import ast
 import math
+import imp
 
 from roslaunch import substitution_args
 from rospkg.common import ResourceNotFound
@@ -58,6 +59,9 @@ substitution_args_context = {}
 
 # Stack of currently processed files
 filestack = []
+
+# List of imported user modules
+modules = []
 
 def push_file(filename):
     """
@@ -861,8 +865,16 @@ def eval_all(node, macros, symbols):
                 else:
                     replace_node(node, by=None)
 
+            elif node.tagName == 'xacro:python':
+                path, module = [eval_text(a, symbols) for a in reqd_attrs(node, ['file', 'module'])]
+                modules.append(imp.load_source(module, path))
+                replace_node(node, by=None)
+
             elif handle_macro_call(node, macros, symbols):
                 pass  # handle_macro_call does all the work of expanding the macro
+
+            elif handle_python_call(node, symbols):
+                pass
 
             else:
                 # these are the non-xacro tags
@@ -876,6 +888,29 @@ def eval_all(node, macros, symbols):
             node.data = str(eval_text(node.data, symbols))
 
         node = next
+
+def handle_python_call(node, symbols):
+    macro_name = node.tagName.split(":")[-1]
+
+    function = None
+    for m in modules:
+        if hasattr(m, macro_name):
+            function = getattr(m, macro_name)
+
+    if not function:
+        return False
+
+    kwargs = {}
+    for name, value in node.attributes.items():
+        kwargs[name] = eval_text(value, symbols)
+
+    substitution = function(**kwargs)
+    parsed = xml.dom.minidom.parseString(substitution)
+
+    remove_previous_comments(node)
+    replace_node(node, by=parsed, content_only=True)
+
+    return True
 
 
 def parse(inp, filename=None):


### PR DESCRIPTION
Heres a rough sketch of what I was referring to in #168. I put this together to work with [this](https://github.com/Zabot/mesh_tools/blob/master/scripts/hardware.py) python script which generates the link properties given a mesh. The macro is included by [this](https://github.com/Zabot/mesh_tools/blob/master/urdf/example.urdf.xacro) xacro.

I added one additional tag, `xacro:python` which has a two attributes `file` and `module`. Adding an `xacro:python` tag will import `module` from `file`. Macro calls will tested against the attributes defined in imported `module`s if they don't match any existing macros, and if a matching attribute is found that attribute will be called and passed the attributes of the macro as keyword arguments.

In an xacro file:
```xml
<xacro:python file="$(find some_package)/scripts/useful.py" module="useful"/>
<xacro:complex_macro foo="foobar" bar="foobar"/>
```

useful.py:
```python
def complex_macro(foo, bar):
    return '<link name="{}"/>'.format(foo + bar)
```

I'm not a huge fan of how XML elements are passed to and from the user function call (being stringified, and then parsed out both ways), but I wanted to get the idea out for comment. Because the user function is actually being imported as opposed to just being `eval`ed, we could allow for stronger typing/pass actual DOM elements back and forth.