### PR TITLE
fix formatting of XacroException

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -130,7 +130,7 @@ class XacroException(Exception):
 
     def __str__(self):
         items = [super(XacroException, self).__str__(), self.exc, self.suffix]
-        return ' '.join([str(e) for e in items if e])
+        return ' '.join([str(e) for e in items if e not in ['', 'None']])
 
 
 verbosity = 1
@@ -1032,7 +1032,7 @@ def main():
         sys.exit(2)  # indicate failure, but don't print stack trace on XML errors
 
     except Exception as e:
-        msg = error(str(e))
+        msg = str(e)
         if not msg: msg = repr(e)
         error(msg)
         if verbosity > 0:


### PR DESCRIPTION
This PR improves formatting of xacro exceptions. Instead of 
```
None name 'prop1' is not defined 
when evaluating expression 'prop1'
XacroException(None,)
when processing file: ifdef.xml
```

the message now becomes:
```
name 'prop1' is not defined 
when evaluating expression 'prop1'
when processing file: ifdef.xml
```
