### PR TITLE
allow default values for properties

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1170,6 +1170,24 @@ class TestXacroInorder(TestXacro):
             self.assertTrue("foo" in output)  # foo should be reported
             self.assertTrue("bar" not in output)  # bar shouldn't be reported
 
+    def test_default_property(self):
+        src = '''
+        <a xmlns:xacro="http://www.ros.org/xacro">
+            <xacro:property name="prop" default="false"/>
+            <xacro:unless value="${prop}">
+                <foo/>
+                <xacro:property name="prop" value="true"/>
+            </xacro:unless>
+
+            <!-- second foo should be ignored -->
+            <xacro:unless value="${prop}">
+                <foo/>
+                <xacro:property name="prop" value="true"/>
+            </xacro:unless>
+        </a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/xacro"><foo/></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows for definition of default values for properties (much like it is possible for arguments):

```xml
<a xmlns:xacro="http://www.ros.org/xacro">
	<xacro:property name="prop" default="false"/>
	<xacro:unless value="${prop}">
		<foo/>
		<xacro:property name="prop" value="true"/>
	</xacro:unless>

	<!-- second foo should be ignored -->
	<xacro:unless value="${prop}">
		<foo/>
		<xacro:property name="prop" value="true"/>
	</xacro:unless>
</a>
```
