### PR TITLE
python builtins: allow max, min

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -109,7 +109,7 @@ def load_yaml(filename):
 # taking simple security measures to forbid access to __builtins__
 # only the very few symbols explicitly listed are allowed
 # for discussion, see: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int']}}
+global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int', 'max', 'min']}}
 # also define all math symbols and functions
 global_symbols.update(math.__dict__)
 # allow to import dicts from yaml


### PR DESCRIPTION
Retargeting #178 to `melodic-devel`:

Only a subset of python builtin functions are permitted in xacro `${}` expressions for security reasons, for reasons listed [here](http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html). I recently wanted to use `min` and `max` in a xacro file, so I wonder if they can be added to this list.

I looked at the list of python builtin functions that could be useful for math operations, and many of them have alternatives since we import `math.*`:

* `abs`: use `math.fabs`
* `len`: use `.__len__()` object method
* `pow`: use `**`
* `sum`: use `math.fsum`

The only other one I would consider adding is `round`. You can get partial functionality with `math.floor` and `math.ceil`, but not the same. Currently, though, I just need `max` and `min`. I would propose back porting this if it is acceptable.