### PR TITLE
fix parsing of parameter defaults surrounded with single exclamation …

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -481,6 +481,9 @@ def parse_macro_arg(s):
         # there is a default value specified for param
         param, forward, default, rest = m.groups()
         if not default: default = None
+        if default.startswith("'") and default.endswith("'"):
+            default = default[1:-1]
+        print(param, default)
         return param, (param if forward else None, default), rest
     else:
         # there is no default specified at all

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -481,9 +481,9 @@ def parse_macro_arg(s):
         # there is a default value specified for param
         param, forward, default, rest = m.groups()
         if not default: default = None
-        if default.startswith("'") and default.endswith("'"):
-            default = default[1:-1]
-        print(param, default)
+        else:
+            if default.startswith("'") and default.endswith("'"):
+                default = default[1:-1]
         return param, (param if forward else None, default), rest
     else:
         # there is no default specified at all

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -359,6 +359,18 @@ class TestXacro(TestXacroCommentsIgnored):
         res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><tag A="foo"/><tag B="bar"/></a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
+    def test_xacro_attribute_with_spaces(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="foo" params="x:='0.0 0.0 0.0' rot='0 0 0 1' unused=''">
+  <tag><xacro:attribute name="${name}" value="${value}"/></tag>
+  </xacro:macro>
+  <xacro:foo name="A" value="foo"/>
+  <xacro:foo name="B" value="bar"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><tag A="foo"/><tag B="bar"/></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+
     def test_inorder_processing(self):
         src = '''<xml xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="foo" value="1.0"/>


### PR DESCRIPTION
This patch fixes parsing of parameter defaults that are surrounded by single exclamation marks (e.g. to escape space characters)

Example: params="xyz:='0 0 0'" 

Without the patch, parameter values keep the exclamation marks.
With the patch, parsing behaves like in the lunar release (exclamation marks are stripped)