### PR TITLE
fix parsing of quoted strings in default args for xacro params

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -210,6 +210,9 @@ class Table(object):
     @staticmethod
     def _eval_literal(value):
         if isinstance(value, _basestr):
+            # remove single quotes from escaped string
+            if len(value) >= 2 and value[0] == "'" and value[-1] == "'":
+                return value[1:-1]
             # try to evaluate as number literal or boolean
             # this is needed to handle numbers in property definitions as numbers, not strings
             for f in [int, float, lambda x: get_boolean_value(x, None)]: # order of types is important!

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -402,6 +402,12 @@ class TestXacro(TestXacroCommentsIgnored):
   <foo lst="${[1,2,3]}"/></a>'''),
         '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">3</a>''')
 
+    def test_macro_params_escaped_string(self):
+        self.assert_matches(self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:macro name="foo" params="a='1 -2' c=3"><bar a="${a}" c="${c}"/></xacro:macro>
+    <xacro:foo/></a>'''),
+                            '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"><bar a="1 -2" c="3"/></a>''')
+
     def test_property_replacement(self):
         self.assert_matches(
                 self.quick_xacro('''<a xmlns:xacro="http://www.ros.org/wiki/xacro">


### PR DESCRIPTION
As pointed out in #186, parsing of macro params involving single-quoted strings is failing:
Example: `params="xyz:='0 0 0'"`

This is due to a change in f5367e9dd2391c8e7f733604aadbabbc81b5915f.
Handling this particular case now as well.