### PR TITLE
WIP: Interpret relative filenames w.r.t. to macro-defining file

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -748,6 +748,7 @@ def handle_macro_call(node, macros, symbols):
     if params:
         raise XacroException("Undefined parameters [%s]" % ",".join(params), macro=m)
 
+    oldstack = push_file(m.history[-1][-1])
     try:
         eval_all(body, macros, scoped)
     except Exception as e:
@@ -757,6 +758,8 @@ def handle_macro_call(node, macros, symbols):
         else:
             e.macros = [m]
         raise
+    finally:
+        restore_filestack(oldstack)
 
     # Replaces the macro node with the expansion
     remove_previous_comments(node)


### PR DESCRIPTION
Currently, when xacro:including files with relative names, the full filename is constructed from the currently processed file and the relative name. While this seems to be a clear definition, it is ambiguous in case of macros: Macros might be defined in one file and used/called from another one. In this case, the question arises whether relative filenames should be interpreted w.r.t. the macro-defining or the macro-calling file.

While I dediced for the latter variant originally, this PR shows that the former variant is easily implemented as well. Both options might have their pros and cons.

Thinking more about it, relative filenames should not be passed via properties as well, because this raises another ambiguity: The property could be passed through several levels of macros and then again, it's not immediately clear at which level the relative filename is resolved.
For such a use case, we should introduce a function `absolute_file_name()`, which can be used at the location of the property definition, to turn a relative name into an absolute one - considering the currently processed file as the reference point.

I'm hoping for some feedback from the community to decide which option to choose.