### PR TITLE
remove duplicate catkin_python_setup()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ project(xacro)
 
 find_package(catkin REQUIRED roslint)
 
-catkin_python_setup()
-
 catkin_package(
   CFG_EXTRAS xacro-extras.cmake
 )


### PR DESCRIPTION
this change aims to address https://github.com/ros/xacro/issues/205, by reducing the number of `catkin_python_setup()` calls to only 1