### PR TITLE
Add `len()` to allowed Python builtins

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -112,7 +112,7 @@ def load_yaml(filename):
 # taking simple security measures to forbid access to __builtins__
 # only the very few symbols explicitly listed are allowed
 # for discussion, see: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int', 'True', 'False', 'min', 'max', 'round']}}
+global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int', 'True', 'False', 'min', 'max', 'round', 'len']}}
 # also define all math symbols and functions
 global_symbols.update(math.__dict__)
 # allow to import dicts from yaml

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -112,7 +112,7 @@ def load_yaml(filename):
 # taking simple security measures to forbid access to __builtins__
 # only the very few symbols explicitly listed are allowed
 # for discussion, see: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int', 'True', 'False', 'min', 'max', 'round', 'len']}}
+global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'len', 'str', 'float', 'int', 'True', 'False', 'min', 'max', 'round']}}
 # also define all math symbols and functions
 global_symbols.update(math.__dict__)
 # allow to import dicts from yaml


### PR DESCRIPTION
Allows to create a loop like this one:

    <xacro:macro name="include_payload_xacros" params="xacros">
        <xacro:if value="${len(xacros) > 0}">
            <xacro:include filename="${xacros[0]}" />
            <xacro:include_payload_xacros xacros="${xacros[1:]}" />
        </xacro:if>
    </xacro:macro>
    <xacro:include_payload_xacros xacros="${$(arg payload_xacros)}" />

Without this PR, you need to use the `list.__len__()` function, which is not so nice, but it also works.