### PR TITLE
Changed in favour of package_shared_directory

### DIFF
--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -31,7 +31,7 @@ import sys
 
 import yaml
 
-from ament_index_python.packages import get_package_prefix
+from ament_index_python.packages import get_package_share_directory
 
 
 try:
@@ -171,7 +171,7 @@ def _dirname(resolved, a, args, context):
 
 
 def _eval_find(pkg):
-    return get_package_prefix(pkg)
+    return get_package_share_directory(pkg)
 
 
 def _find(resolved, a, args, context):
@@ -212,7 +212,7 @@ def _find(resolved, a, args, context):
                 pass
         if res is not None:
             return res
-    pkg_path = get_package_prefix(args[0])
+    pkg_path = get_package_share_directory(args[0])
     if path:
         pkg_path = os.path.join(pkg_path, path)
     return before + pkg_path + after


### PR DESCRIPTION
Signed-off-by: Gonzalo de Pedro <gonzalo@depedro.com.ar>

_drop get_package_prefix_ in favor of _get_package_share_directory_