### PR TITLE
Noetic branch: remove deprecated stuff

### DIFF
--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -1,11 +1,11 @@
 add_custom_target(${PROJECT_NAME}_xacro_generated_to_devel_space_ ALL)
 
 
-## xacro_add_xacro_file(<input> [<output>] [LEGACY] [REMAP <arg> <arg> ...]
+## xacro_add_xacro_file(<input> [<output>] [REMAP <arg> <arg> ...]
 ##                      [OUTPUT <variable>] DEPENDS <arg> <arg>)
 ##
 ## Creates a command to run xacro on <input> like so:
-## xacro [--legacy] -o <output> <input> [<remap args>]
+## xacro -o <output> <input> [<remap args>]
 ##
 ## If <output> was not specified, it is determined from <input> removing the suffix .xacro
 ## The absolute output file name is returned in variable <output>, which defaults to
@@ -26,7 +26,7 @@ add_custom_target(${PROJECT_NAME}_xacro_generated_to_devel_space_ ALL)
 ##                 TARGET xacro_target INSTALL DESTINATION xml)
 function(xacro_add_xacro_file input)
   # parse arguments
-  set(options INORDER LEGACY)
+  set(options)
   set(oneValueArgs OUTPUT)
   set(multiValueArgs REMAP DEPENDS)
   cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -51,16 +51,6 @@ function(xacro_add_xacro_file input)
   endif()
   # message(STATUS "output: ${output}")
 
-  # process _XACRO_INORDER / _XACRO_LEGACY options
-  if(_XACRO_INORDER) # INORDER takes precedence over LEGACY
-    set(_XACRO_LEGACY FALSE)
-  endif()
-  if(_XACRO_LEGACY)
-    set(_XACRO_LEGACY "LEGACY")
-  else()
-    unset(_XACRO_LEGACY)
-  endif()
-
   ## determine absolute output target location
   if(IS_ABSOLUTE ${output})
     set(abs_output ${output})
@@ -77,7 +67,7 @@ function(xacro_add_xacro_file input)
 
   ## Call out to xacro to determine dependencies
   message(STATUS "xacro: determining deps for: " ${input} " ...")
-  execute_process(COMMAND ${CATKIN_ENV} xacro ${_XACRO_LEGACY} --deps ${input} ${_XACRO_REMAP}
+  execute_process(COMMAND ${CATKIN_ENV} xacro --deps ${input} ${_XACRO_REMAP}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE _xacro_result
     ERROR_VARIABLE _xacro_err
@@ -92,7 +82,7 @@ ${_xacro_err}")
 
   ## command to actually call xacro
   add_custom_command(OUTPUT ${output}
-    COMMAND ${CATKIN_ENV} xacro ${_XACRO_LEGACY} -o ${abs_output} ${input} ${_XACRO_REMAP}
+    COMMAND ${CATKIN_ENV} xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
     DEPENDS ${input} ${_xacro_deps_result} ${_XACRO_DEPENDS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "xacro: generating ${output} from ${input}"
@@ -143,7 +133,7 @@ function(xacro_install target)
 endfunction(xacro_install)
 
 
-## xacro_add_files(<file> [<file> ...] [LEGACY] [REMAP <arg> <arg> ...] [DEPENDS <arg> <arg>]
+## xacro_add_files(<file> [<file> ...] [REMAP <arg> <arg> ...] [DEPENDS <arg> <arg>]
 ##                 [TARGET <target>] [INSTALL [DESTINATION <path>]])
 ##
 ## create make <target> to generate xacro files
@@ -151,22 +141,12 @@ endfunction(xacro_install)
 ## in devel and install space.
 function(xacro_add_files)
   # parse arguments
-  set(options INORDER LEGACY INSTALL)
+  set(options INSTALL)
   set(oneValueArgs OUTPUT TARGET DESTINATION)
   set(multiValueArgs REMAP DEPENDS)
   cmake_parse_arguments(_XACRO "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   ## process arguments
-  # process _XACRO_INORDER / _XACRO_LEGACY options
-  if(_XACRO_INORDER) # INORDER takes precedence over LEGACY
-    set(_XACRO_LEGACY FALSE)
-  endif()
-  if(_XACRO_LEGACY)
-    set(_XACRO_LEGACY "LEGACY")
-  else()
-    unset(_XACRO_LEGACY)
-  endif()
-
   # prepare REMAP args (prepending REMAP)
   if(_XACRO_REMAP)
     set(_XACRO_REMAP REMAP ${_XACRO_REMAP})
@@ -184,7 +164,7 @@ function(xacro_add_files)
 
   foreach(input ${_XACRO_UNPARSED_ARGUMENTS})
     # call to main function
-    xacro_add_xacro_file(${input} ${_XACRO_OUTPUT} ${_XACRO_LEGACY} ${_XACRO_REMAP} ${_XACRO_DEPENDS})
+    xacro_add_xacro_file(${input} ${_XACRO_OUTPUT} ${_XACRO_REMAP} ${_XACRO_DEPENDS})
     list(APPEND outputs ${XACRO_OUTPUT_FILE})
   endforeach()
 

--- a/src/xacro/cli.py
+++ b/src/xacro/cli.py
@@ -65,8 +65,6 @@ def process_args(argv, require_input=True):
                       help="write output to FILE instead of stdout")
     parser.add_option("--deps", action="store_true", dest="just_deps",
                       help="print file dependencies")
-    parser.add_option("--xacro-ns", action="store_false", default=True, dest="xacro_ns",
-                      help="require xacro namespace prefix for xacro tags")
     parser.add_option("--inorder", "-i", action="store_true", dest="in_order",
                       help="processing in read order (default, can be omitted)")
 

--- a/src/xacro/cli.py
+++ b/src/xacro/cli.py
@@ -63,23 +63,16 @@ def process_args(argv, require_input=True):
                                  formatter=IndentedHelpFormatterWithNL())
     parser.add_option("-o", dest="output", metavar="FILE",
                       help="write output to FILE instead of stdout")
-    parser.add_option("--inorder", "-i", action="store_true", dest="in_order",
-                      help="use processing in read order [default]")
-    parser.add_option("--legacy", action="store_false", dest="in_order",
-                      help="use legacy processing order [deprecated]")
-    parser.add_option("--check-order", action="store_true", dest="do_check_order",
-                      help="check document for inorder processing", default=False)
-
     parser.add_option("--deps", action="store_true", dest="just_deps",
                       help="print file dependencies")
-    parser.add_option("--includes", action="store_true", dest="just_includes",
-                      help="only process includes [deprecated]")
     parser.add_option("--xacro-ns", action="store_false", default=True, dest="xacro_ns",
                       help="require xacro namespace prefix for xacro tags")
+    parser.add_option("--inorder", "-i", action="store_true", dest="in_order",
+                      help="processing in read order (default, can be omitted)")
 
     # verbosity options
     parser.add_option("-q", action="store_const", dest="verbosity", const=0,
-                      help="quiet operation suppressing warnings")
+                      help="quiet operation, suppressing warnings")
     parser.add_option("-v", action="count", dest="verbosity",
                       help="increase verbosity")
     parser.add_option("--verbosity", metavar='level', dest="verbosity", type='int',
@@ -103,26 +96,9 @@ def process_args(argv, require_input=True):
 
     parser.set_defaults(just_deps=False, just_includes=False, verbosity=1)
     (options, pos_args) = parser.parse_args(filtered_args)
-    if options.in_order is None:
-        # --inorder is default, but it's incompatible to --includes
-        options.in_order = not options.just_includes
-    elif options.in_order == True:
+    if options.in_order == True:
         message("xacro: in-order processing became default in ROS Melodic. You can drop the option.")
-    if options.in_order == False:
-        warning("xacro: Legacy processing is deprecated since ROS Jade and will be removed in N-turtle.")
-        message("To check for compatibility of your document, use option --check-order.", color='yellow')
-        message("For more infos, see http://wiki.ros.org/xacro#Processing_Order", color='yellow')
-
-    if options.just_includes:
-        warning("xacro: option --includes is deprecated")
-
-    # --inorder is incompatible to --includes: --inorder processing starts evaluation
-    # while --includes should return the unmodified document
-    if options.in_order and options.just_includes:
-        parser.error("options --inorder and --includes are mutually exclusive")
-
-    if options.do_check_order:
-        options.in_order = True  # check-order implies inorder
+    options.in_order = True
 
     if len(pos_args) != 1:
         if require_input:


### PR DESCRIPTION
Since Melodic, `--inorder` processing is the default. Old-style `--legacy` processing is deprecated since Jade. It's time to get rid of this old code...
Same applies for requiring the `xacro:` prefix for all xacro commands.