### PR TITLE
Revert: require all xacro commands to be prefixed with 'xacro:'

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -578,7 +578,7 @@ class TestXacro(TestXacroCommentsIgnored):
   <xacro:property name="var" value="main"/>
   <xacro:include filename="include1.xacro" ns="A"/>
   <xacro:include filename="include2.xacro" ns="B"/>
-  <xacro:A.foo/><xacro:B.foo/>
+  <xacro:A.foo/><B.foo/>
   <main var="${var}" A="${2*A.var}" B="${B.var+1}"/>
 </a>'''
         res = '''
@@ -1210,6 +1210,14 @@ ${u'🍔' * how_many}
         self.assertTrue(os.path.isfile(output_path))
         self.assert_matches(xml.dom.minidom.parse(output_path), '''<robot>🍔</robot>''')
         shutil.rmtree(tmp_dir_name)  # clean up after ourselves
+
+    def test_macro_name_clash(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+<xacro:macro name="foo"><bar/></xacro:macro>
+<foo/></a>
+'''
+        self.assert_matches(self.quick_xacro(src, ['--xacro-ns']), '<a><foo/></a>')
+        self.assert_matches(self.quick_xacro(src), '<a><bar/></a>')
 
 
 if __name__ == '__main__':

--- a/xacro/cli.py
+++ b/xacro/cli.py
@@ -99,6 +99,8 @@ def process_args(argv, require_input=True):
                       help="write output to FILE instead of stdout")
     parser.add_option("--deps", action="store_true", dest="just_deps",
                       help="print file dependencies")
+    parser.add_option("--xacro-ns", action="store_false", default=True, dest="xacro_ns",
+                      help="require xacro namespace prefix for xacro tags")
     parser.add_option("--inorder", "-i", action="store_true", dest="in_order",
                       help="processing in read order (default, can be omitted)")
 


### PR DESCRIPTION
As the corresponding deprecation warning wasn't issued in previous releases,
we will accept non-prefixed xacro tags until F-turtle.