### PR TITLE
Expose abs_filename()

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -115,8 +115,8 @@ def load_yaml(filename):
 global_symbols = {'__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'len', 'str', 'float', 'int', 'True', 'False', 'min', 'max', 'round']}}
 # also define all math symbols and functions
 global_symbols.update(math.__dict__)
-# allow to import dicts from yaml
-global_symbols.update(dict(load_yaml=load_yaml))
+# expose load_yaml and abs_filename
+global_symbols.update(dict(load_yaml=load_yaml, abs_filename=abs_filename_spec))
 
 
 class XacroException(Exception):

--- a/test/subdir/foo.xacro
+++ b/test/subdir/foo.xacro
@@ -1,0 +1,3 @@
+<a xmlns:xacro="http://www.ros.org/xacro">
+    <xacro:foo/>
+</a>

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1107,6 +1107,18 @@ class TestXacroInorder(TestXacro):
   </xacro:if>
 </a>'''), '<a/>')
 
+    def test_include_from_macro(self):
+        src = '''
+    <a xmlns:xacro="http://www.ros.org/xacro">
+      <xacro:macro name="foo" params="file:=include1.xml"><xacro:include filename="${file}"/></xacro:macro>
+      <xacro:foo/>
+      <xacro:foo file="${abs_filename('include1.xml')}"/>
+      <xacro:include filename="subdir/foo.xacro"/>
+      <xacro:foo file="$(cwd)/subdir/include1.xml"/>
+    </a>'''
+        res = '''<a><inc1/><inc1/><subdir_inc1/><subdir_inc1/></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
     def test_yaml_support(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">


### PR DESCRIPTION
As suggested in https://github.com/ros/xacro/pull/201#issue-231131840, the user needs to decide when (w.r.t. which file context) a relative filename should be resolved to an absolute one. This PR exposes the method `abs_filename()`, which allows resolving a filename in the current file's context.
Closes #201.