### PR TITLE
Enable launching xacro easily from ros2 launch files

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1216,6 +1216,11 @@ ${u'🍔' * how_many}
         self.assert_matches(self.quick_xacro(src, ['--xacro-ns']), '<a><foo/></a>')
         self.assert_matches(self.quick_xacro(src), '<a><bar/></a>')
 
+    def test_process_return_value(self):
+        test_dir = os.path.abspath(os.path.dirname(__file__))
+        input_path = os.path.join(test_dir, 'emoji.xacro')
+        self.assert_matches(xacro.process(input_path), '<robot>🍔</robot>')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -1034,11 +1034,6 @@ def _process(input_file_name, opts):
         out.close()
 
 
-def main():
-    opts, input_file_name = process_args(sys.argv[1:])
-    _process(input_file_name, vars(opts))
-
-
 def process(input_file_name, just_deps=False, xacro_ns=True, verbosity=1, mappings={}):
     """Function to be used from python code, returning the processed XML"""
     from io import StringIO
@@ -1048,3 +1043,8 @@ def process(input_file_name, just_deps=False, xacro_ns=True, verbosity=1, mappin
     result = sys.stdout.read()
     sys.stdout = old  # restore sys.stdout
     return result
+
+
+def main():
+    opts, input_file_name = process_args(sys.argv[1:])
+    _process(input_file_name, vars(opts))

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -1044,7 +1044,6 @@ def exec(input_file_name, opts):
             sys.exit(2)  # gracefully exit with error condition
 
     # special output mode
-    #if opts.just_deps:
     if opts['just_deps']:
         out.write(' '.join(set(all_includes)))
         out.write('\n')

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -991,11 +991,11 @@ def process_file(input_file_name, **kwargs):
     return doc
 
 
-def process(input_file_name, output=None, in_order=True, do_check_order=False,
+def process(input_file_name, output_file_name, in_order=True, do_check_order=False,
             just_deps=False, just_includes=False, xacro_ns=True, verbosity=1, mappings={}):
 
     opts_map = {
-        'output': output,
+        'output': output_file_name,
         'in_order': in_order,
         'do_check_order': do_check_order,
         'just_deps': just_deps,
@@ -1007,9 +1007,6 @@ def process(input_file_name, output=None, in_order=True, do_check_order=False,
 
     return exec(input_file_name, opts_map)
 
-def main():
-    opts, input_file_name = process_args(sys.argv[1:])
-    exec(input_file_name, vars(opts))
 
 def exec(input_file_name, opts):
 
@@ -1029,7 +1026,7 @@ def exec(input_file_name, opts):
             print('Check that:', file=sys.stderr)
             print(' - Your XML is well-formed', file=sys.stderr)
             print(' - You have the xacro xmlns declaration:',
-                  'xmlns:xacro=\"http://www.ros.org/wiki/xacro\"', file=sys.stderr)
+                  'xmlns:xacro="http://www.ros.org/wiki/xacro"', file=sys.stderr)
         # indicate failure, but don't print stack trace on XML errors
         sys.exit(2)
 
@@ -1050,13 +1047,19 @@ def exec(input_file_name, opts):
     #if opts.just_deps:
     if opts['just_deps']:
         out.write(' '.join(set(all_includes)))
-        print()
-        return ' '.join(set(all_includes))
+        out.write('\n')
+        if opts['output']:
+            out.close()
+        return
 
     # write output
     out.write(doc.toprettyxml(indent='  '))
-    print()
     # only close output file, but not stdout
     if opts['output']:
         out.close()
-    return doc.toprettyxml(indent='  ')
+    return
+
+
+def main():
+    opts, input_file_name = process_args(sys.argv[1:])
+    exec(input_file_name, vars(opts))

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -991,15 +991,11 @@ def process_file(input_file_name, **kwargs):
     return doc
 
 
-def process(input_file_name, output_file_name, in_order=True, do_check_order=False,
-            just_deps=False, just_includes=False, xacro_ns=True, verbosity=1, mappings={}):
-
+def process(input_file_name, output_file_name, just_deps=False, xacro_ns=True, verbosity=1, mappings={}):
+    """Processing function to be used from python code directly"""
     opts_map = {
         'output': output_file_name,
-        'in_order': in_order,
-        'do_check_order': do_check_order,
         'just_deps': just_deps,
-        'just_includes': just_includes,
         'xacro_ns': xacro_ns,
         'verbosity': verbosity,
         'mappings': mappings,

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -1005,8 +1005,6 @@ def process(input_file_name, output_file_name, just_deps=False, xacro_ns=True, v
 
 
 def exec(input_file_name, opts):
-
-    from xml.parsers.expat import ExpatError
     try:
         # open and process file
         doc = process_file(input_file_name, **opts)
@@ -1014,7 +1012,7 @@ def exec(input_file_name, opts):
         out = open_output(opts['output'])
 
     # error handling
-    except ExpatError as e:
+    except xml.parsers.expat.ExpatError as e:
         error('XML parsing error: %s' % str(e), alt_text=None)
         if verbosity > 0:
             print_location(filestack, e)
@@ -1039,20 +1037,14 @@ def exec(input_file_name, opts):
         else:
             sys.exit(2)  # gracefully exit with error condition
 
-    # special output mode
-    if opts['just_deps']:
+    if opts['just_deps']:  # only output list of dependencies
         out.write(' '.join(set(all_includes)))
-        out.write('\n')
-        if opts['output']:
-            out.close()
-        return
+    else:  # write XML output
+        out.write(doc.toprettyxml(indent='  '))
 
-    # write output
-    out.write(doc.toprettyxml(indent='  '))
     # only close output file, but not stdout
     if opts['output']:
         out.close()
-    return
 
 
 def main():

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -991,20 +991,7 @@ def process_file(input_file_name, **kwargs):
     return doc
 
 
-def process(input_file_name, output_file_name, just_deps=False, xacro_ns=True, verbosity=1, mappings={}):
-    """Processing function to be used from python code directly"""
-    opts_map = {
-        'output': output_file_name,
-        'just_deps': just_deps,
-        'xacro_ns': xacro_ns,
-        'verbosity': verbosity,
-        'mappings': mappings,
-    }
-
-    return exec(input_file_name, opts_map)
-
-
-def exec(input_file_name, opts):
+def _process(input_file_name, opts):
     try:
         # open and process file
         doc = process_file(input_file_name, **opts)
@@ -1049,4 +1036,16 @@ def exec(input_file_name, opts):
 
 def main():
     opts, input_file_name = process_args(sys.argv[1:])
-    exec(input_file_name, vars(opts))
+    _process(input_file_name, vars(opts))
+
+
+def process(input_file_name, output_file_name, just_deps=False, xacro_ns=True, verbosity=1, mappings={}):
+    """Processing function to be used from python code directly"""
+    opts_map = {
+        'output': output_file_name,
+        'just_deps': just_deps,
+        'xacro_ns': xacro_ns,
+        'verbosity': verbosity,
+        'mappings': mappings,
+    }
+    _process(input_file_name, opts_map)

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -1039,13 +1039,12 @@ def main():
     _process(input_file_name, vars(opts))
 
 
-def process(input_file_name, output_file_name, just_deps=False, xacro_ns=True, verbosity=1, mappings={}):
-    """Processing function to be used from python code directly"""
-    opts_map = {
-        'output': output_file_name,
-        'just_deps': just_deps,
-        'xacro_ns': xacro_ns,
-        'verbosity': verbosity,
-        'mappings': mappings,
-    }
-    _process(input_file_name, opts_map)
+def process(input_file_name, just_deps=False, xacro_ns=True, verbosity=1, mappings={}):
+    """Function to be used from python code, returning the processed XML"""
+    from io import StringIO
+    old, sys.stdout = sys.stdout, StringIO()  # temporarily replace sys.stdout with StringIO()
+    _process(input_file_name, dict(output=None, just_deps=just_deps, xacro_ns=xacro_ns, verbosity=verbosity, mappings=mappings))
+    sys.stdout.seek(0)
+    result = sys.stdout.read()
+    sys.stdout = old  # restore sys.stdout
+    return result

--- a/xacro/cli.py
+++ b/xacro/cli.py
@@ -127,7 +127,7 @@ def process_args(argv, require_input=True):
         mappings = {}
         filtered_args = argv
 
-    parser.set_defaults(just_deps=False, just_includes=False, verbosity=1)
+    parser.set_defaults(just_deps=False, verbosity=1)
     (options, pos_args) = parser.parse_args(filtered_args)
     if options.in_order:
         message("xacro: in-order processing became default in ROS Melodic. You can drop the option.")


### PR DESCRIPTION
This PR creates a 'process' method in xacro to enable launching it from launch files, like:

`xacro.process(urdf_file, robot_urdf)`