### PR TITLE
handling non optional existence in xacro files

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -362,12 +362,14 @@ def is_include(elt):
     return True
 
 
-def get_include_files(filename_spec, symbols):
+def get_include_files(filename_spec, symbols, optional=False):
     try:
         filename_spec = abs_filename_spec(eval_text(filename_spec, symbols))
     except XacroException as e:
         if e.exc and isinstance(e.exc, NameError) and symbols is None:
             raise XacroException('variable filename is supported with --inorder option only')
+        elif e.exc.strerror == "No such file or directory" and optional is True:
+            return
         else:
             raise
 
@@ -402,7 +404,7 @@ def import_xml_namespaces(parent, attributes):
 
 def process_include(elt, macros, symbols, func):
     included = []
-    filename_spec, namespace_spec = check_attrs(elt, ['filename'], ['ns'])
+    filename_spec, namespace_spec, optional = check_attrs(elt, ['filename'], ['ns', 'optional'])
     if namespace_spec:
         try:
             namespace_spec = eval_text(namespace_spec, symbols)
@@ -413,18 +415,27 @@ def process_include(elt, macros, symbols, func):
         except TypeError:
             raise XacroException('namespaces are supported with --inorder option only')
 
-    for filename in get_include_files(filename_spec, symbols):
+    optional = True if optional == "True" else False
+
+    for filename in get_include_files(filename_spec, symbols, optional):
         # extend filestack
         oldstack = push_file(filename)
-        include = parse(None, filename).documentElement
+        try:
+            include = parse(None, filename).documentElement
 
-        # recursive call to func
-        func(include, macros, symbols)
-        included.append(include)
-        import_xml_namespaces(elt.parentNode, include.attributes)
+            # recursive call to func
+            func(include, macros, symbols)
+            included.append(include)
+            import_xml_namespaces(elt.parentNode, include.attributes)
 
-        # restore filestack
-        restore_filestack(oldstack)
+            # restore filestack
+            restore_filestack(oldstack)
+
+        except XacroException as e:
+            if e.exc.strerror == "No such file or directory" and optional is True:
+                continue
+            else:
+                raise
 
     remove_previous_comments(elt)
     # replace the include tag with the nodes of the included file(s)
@@ -914,7 +925,7 @@ def parse(inp, filename=None):
         except IOError as e:
             # do not report currently processed file as "in file ..."
             filestack.pop()
-            raise XacroException(e.strerror + ": " + e.filename)
+            raise XacroException(e.strerror + ": " + e.filename, exc=e)
 
     try:
         if isinstance(inp, _basestr):

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -415,25 +415,25 @@ def process_include(elt, macros, symbols, func):
 
     optional = True if optional == "True" else False
 
-    try:
-        for filename in get_include_files(filename_spec, symbols):
-            # extend filestack
-            oldstack = push_file(filename)
+    for filename in get_include_files(filename_spec, symbols):
+        # extend filestack
+        oldstack = push_file(filename)
+
+        try:
             include = parse(None, filename).documentElement
 
             # recursive call to func
             func(include, macros, symbols)
             included.append(include)
             import_xml_namespaces(elt.parentNode, include.attributes)
-
+        except XacroException as e:
+            if e.exc and isinstance(e.exc, IOError) and optional is True:
+                continue
+            else:
+                raise
+        finally:
             # restore filestack
             restore_filestack(oldstack)
-
-    except XacroException as e:
-        if e.exc and isinstance(e.exc, IOError) and e.exc.strerror == "No such file or directory" and optional is True:
-            pass
-        else:
-            raise
 
     remove_previous_comments(elt)
     # replace the include tag with the nodes of the included file(s)

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -430,7 +430,7 @@ def process_include(elt, macros, symbols, func):
             restore_filestack(oldstack)
 
     except XacroException as e:
-        if e.exc.strerror == "No such file or directory" and optional is True:
+        if e.exc and isinstance(e.exc, IOError) and e.exc.strerror == "No such file or directory" and optional is True:
             pass
         else:
             raise

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -362,14 +362,12 @@ def is_include(elt):
     return True
 
 
-def get_include_files(filename_spec, symbols, optional=False):
+def get_include_files(filename_spec, symbols):
     try:
         filename_spec = abs_filename_spec(eval_text(filename_spec, symbols))
     except XacroException as e:
         if e.exc and isinstance(e.exc, NameError) and symbols is None:
             raise XacroException('variable filename is supported with --inorder option only')
-        elif e.exc.strerror == "No such file or directory" and optional is True:
-            return
         else:
             raise
 
@@ -417,10 +415,10 @@ def process_include(elt, macros, symbols, func):
 
     optional = True if optional == "True" else False
 
-    for filename in get_include_files(filename_spec, symbols, optional):
-        # extend filestack
-        oldstack = push_file(filename)
-        try:
+    try:
+        for filename in get_include_files(filename_spec, symbols):
+            # extend filestack
+            oldstack = push_file(filename)
             include = parse(None, filename).documentElement
 
             # recursive call to func
@@ -431,11 +429,11 @@ def process_include(elt, macros, symbols, func):
             # restore filestack
             restore_filestack(oldstack)
 
-        except XacroException as e:
-            if e.exc.strerror == "No such file or directory" and optional is True:
-                continue
-            else:
-                raise
+    except XacroException as e:
+        if e.exc.strerror == "No such file or directory" and optional is True:
+            pass
+        else:
+            raise
 
     remove_previous_comments(elt)
     # replace the include tag with the nodes of the included file(s)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1119,21 +1119,6 @@ class TestXacroInorder(TestXacro):
             self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
                                 res.format(tag=i))
 
-    def test_yaml_exist_required(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="${load_yaml('non-existent.yaml')}"/>
-</a>'''
-        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
-
-    def test_yaml_exist_optional(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="${load_yaml('non-existent.yaml')}" optional="True"/>
-</a>'''
-        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"></a>'''
-        self.assert_matches(self.quick_xacro(src), res)
-
     def test_xacro_exist_required(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1119,6 +1119,36 @@ class TestXacroInorder(TestXacro):
             self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
                                 res.format(tag=i))
 
+    def test_yaml_exist_required(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="${load_yaml('non-existent.yaml')}"/>
+</a>'''
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
+
+    def test_yaml_exist_optional(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="${load_yaml('non-existent.yaml')}" optional="True"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_xacro_exist_required(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="non-existent.xacro"/>
+</a>'''
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
+
+    def test_xacro_exist_optional(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="non-existent.xacro" optional="True"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
     def test_macro_default_param_evaluation_order(self):
         src='''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:macro name="foo" params="arg:=${2*foo}">


### PR DESCRIPTION
**Use case:**
Being able to load files is currently supported either in xacro files, but these files are required to exist otherwise an exception is thrown. I want to be able to include those files if they exist but if they dont, just continue. This would allow me to override properties from a hardcoded path only if needed like (e.g. ~/.ros/my-custom-calibration.xacro)

**Comments**
I have added the _optional_ support to xacro files and added the unit testing for them. Besides i am merging this in `kinetic-devel` only, we can port it later to `melodic-devel` and friends.