### PR TITLE
Noetic release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(xacro)
 
 find_package(catkin REQUIRED COMPONENTS roslint)
@@ -16,7 +16,7 @@ catkin_install_python(PROGRAMS scripts/xacro
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 ## For backwards compatibility we also install as xacro.py
-#  The roslaunch $(find ...) expects the script to be in the package directory, 
+#  The roslaunch $(find ...) expects the script to be in the package directory,
 #  and in catkin the package direcory is /share.
 install(PROGRAMS xacro.py DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/test/test-xacro-cmake/CMakeLists.txt
+++ b/test/test-xacro-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(xacro-test)
 
 find_package(catkin REQUIRED COMPONENTS xacro)


### PR DESCRIPTION
-  Use setuptools instead of distutils 

Since ros/catkin#1048 catkin prefers to use setuptools instead of distutils. The package.xml doesn't need to include python3-setuptools because [catkin exports that dependency](https://github.com/ros/catkin/blob/86439ec5d2010d5c47c30b815aa97e525037930f/package.xml#L32) for the convenience of all downstream python packages.

-  Bump CMake version to avoid CMP0048

This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Signed-off-by: ahcorde <ahcorde@gmail.com>