### PR TITLE
optional includes

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -314,12 +314,14 @@ all_includes = []
 include_no_matches_msg = """Include tag's filename spec \"{}\" matched no files."""
 
 
-def get_include_files(filename_spec, symbols):
+def get_include_files(filename_spec, symbols, optional=False):
     try:
         filename_spec = abs_filename_spec(eval_text(filename_spec, symbols))
     except XacroException as e:
         if e.exc and isinstance(e.exc, NameError) and symbols is None:
             raise XacroException('variable filename is supported with in-order option only')
+        elif e.exc.strerror == "No such file or directory" and optional is True:
+            return
         else:
             raise
 
@@ -354,7 +356,7 @@ def import_xml_namespaces(parent, attributes):
 
 def process_include(elt, macros, symbols, func):
     included = []
-    filename_spec, namespace_spec = check_attrs(elt, ['filename'], ['ns'])
+    filename_spec, namespace_spec, optional = check_attrs(elt, ['filename'], ['ns', 'optional'])
     if namespace_spec:
         try:
             namespace_spec = eval_text(namespace_spec, symbols)
@@ -365,18 +367,27 @@ def process_include(elt, macros, symbols, func):
         except TypeError:
             raise XacroException('namespaces are supported with in-order option only')
 
-    for filename in get_include_files(filename_spec, symbols):
+    optional = True if optional == "True" else False
+
+    for filename in get_include_files(filename_spec, symbols, optional):
         # extend filestack
         oldstack = push_file(filename)
-        include = parse(None, filename).documentElement
+        try:
+            include = parse(None, filename).documentElement
 
-        # recursive call to func
-        func(include, macros, symbols)
-        included.append(include)
-        import_xml_namespaces(elt.parentNode, include.attributes)
+            # recursive call to func
+            func(include, macros, symbols)
+            included.append(include)
+            import_xml_namespaces(elt.parentNode, include.attributes)
 
-        # restore filestack
-        restore_filestack(oldstack)
+            # restore filestack
+            restore_filestack(oldstack)
+
+        except XacroException as e:
+            if e.exc.strerror == "No such file or directory" and optional is True:
+                continue
+            else:
+                raise
 
     remove_previous_comments(elt)
     # replace the include tag with the nodes of the included file(s)
@@ -831,7 +842,7 @@ def parse(inp, filename=None):
         except IOError as e:
             # do not report currently processed file as "in file ..."
             filestack.pop()
-            raise XacroException(e.strerror + ": " + e.filename)
+            raise XacroException(e.strerror + ": " + e.filename, exc=e)
 
     try:
         if isinstance(inp, _basestr):

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -382,7 +382,7 @@ def process_include(elt, macros, symbols, func):
             restore_filestack(oldstack)
 
     except XacroException as e:
-        if e.exc.strerror == "No such file or directory" and optional is True:
+        if e.exc and isinstance(e.exc, IOError) and e.exc.strerror == "No such file or directory" and optional is True:
             pass
         else:
             raise

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -367,25 +367,25 @@ def process_include(elt, macros, symbols, func):
 
     optional = True if optional == "True" else False
 
-    try:
-        for filename in get_include_files(filename_spec, symbols):
-            # extend filestack
-            oldstack = push_file(filename)
+    for filename in get_include_files(filename_spec, symbols):
+        # extend filestack
+        oldstack = push_file(filename)
+
+        try:
             include = parse(None, filename).documentElement
 
             # recursive call to func
             func(include, macros, symbols)
             included.append(include)
             import_xml_namespaces(elt.parentNode, include.attributes)
-
+        except XacroException as e:
+            if e.exc and isinstance(e.exc, IOError) and optional is True:
+                continue
+            else:
+                raise
+        finally:
             # restore filestack
             restore_filestack(oldstack)
-
-    except XacroException as e:
-        if e.exc and isinstance(e.exc, IOError) and e.exc.strerror == "No such file or directory" and optional is True:
-            pass
-        else:
-            raise
 
     remove_previous_comments(elt)
     # replace the include tag with the nodes of the included file(s)

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -365,13 +365,12 @@ def process_include(elt, macros, symbols, func):
         except TypeError:
             raise XacroException('namespaces are supported with in-order option only')
 
-    optional = True if optional == "True" else False
+    optional = get_boolean_value(optional, None)
 
     for filename in get_include_files(filename_spec, symbols):
-        # extend filestack
-        oldstack = push_file(filename)
-
         try:
+            # extend filestack
+            oldstack = push_file(filename)
             include = parse(None, filename).documentElement
 
             # recursive call to func

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1136,6 +1136,36 @@ class TestXacro(TestXacroCommentsIgnored):
             self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
                                 res.format(tag=i))
 
+    def test_yaml_exist_required(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="${load_yaml('non-existent.yaml')}"/>
+</a>'''
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
+
+    def test_yaml_exist_optional(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="${load_yaml('non-existent.yaml')}" optional="True"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_xacro_exist_required(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="non-existent.xacro"/>
+</a>'''
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
+
+    def test_xacro_exist_optional(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="non-existent.xacro" optional="True"/>
+</a>'''
+        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
     def test_macro_default_param_evaluation_order(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:macro name="foo" params="arg:=${2*foo}">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1136,21 +1136,6 @@ class TestXacro(TestXacroCommentsIgnored):
             self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
                                 res.format(tag=i))
 
-    def test_yaml_exist_required(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="${load_yaml('non-existent.yaml')}"/>
-</a>'''
-        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
-
-    def test_yaml_exist_optional(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="${load_yaml('non-existent.yaml')}" optional="True"/>
-</a>'''
-        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"></a>'''
-        self.assert_matches(self.quick_xacro(src), res)
-
     def test_xacro_exist_required(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1148,7 +1148,7 @@ class TestXacro(TestXacroCommentsIgnored):
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="non-existent.xacro" optional="True"/>
 </a>'''
-        res = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro"></a>'''
+        res = '''<a></a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
     def test_macro_default_param_evaluation_order(self):


### PR DESCRIPTION
Specifying an attribute `optional="True"` for a `xacro:include` tag will silently ignore errors if the file does not exist or is not readable.
This PR is a rebase of #232.