### PR TITLE
Ignore underscores when parsing literal numeric values

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -216,8 +216,12 @@ class Table(object):
             # remove single quotes from escaped string
             if len(value) >= 2 and value[0] == "'" and value[-1] == "'":
                 return value[1:-1]
-            # try to evaluate as number literal or boolean
-            # this is needed to handle numbers in property definitions as numbers, not strings
+            # Try to evaluate as number literal or boolean.
+            # This is needed to handle numbers in property definitions as numbers, not strings.
+            # python3 ignores/drops underscores in number literals (due to PEP515).
+            # Here, we want to handle literals with underscores as plain strings.
+            if '_' in value:
+                return value
             for f in [int, float, lambda x: get_boolean_value(x, None)]:  # order of types is important!
                 try:
                     return f(value)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -999,6 +999,18 @@ class TestXacro(TestXacroCommentsIgnored):
   <a list="[0, 2, 2]" tuple="(0, 2, 2)" dict="{'a': 0, 'c': 2, 'b': 2}"/>
 </a>''')
 
+    def test_literals_eval(self):
+        self.assert_matches(self.quick_xacro('''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="f" value="1.23"/>
+  <xacro:property name="i" value="123"/>
+  <xacro:property name="s" value="1_2_3"/>
+  float=${f+1} int=${i+1} string=${s}
+</a>'''), '''
+<a>
+  float=2.23 int=124 string=1_2_3
+</a>''')
+
     def test_enforce_xacro_ns(self):
         self.assert_matches(self.quick_xacro('''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">


### PR DESCRIPTION
python3, due to PEP515, allows numerical values to be (visually) grouped via underscores.
However, here, we want to consider literals containing an underscore as a string.

Fixes #246.