### PR TITLE
reverting d1171d06d0ebef15eac246ca1b6ef24c3314c9c1

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -94,20 +94,6 @@ def abs_filename_spec(filename_spec):
     return filename_spec
 
 
-class YamlDictWrapper(object):
-    """Wrapper class providing dotted access to dict items"""
-    def __init__(self, d):
-        self.__d = d
-
-    def __getattr__(self, item):
-        try:
-            result = self.__d.__getitem__(item)
-            return YamlDictWrapper(result) if isinstance(result, dict) else result
-        except KeyError:
-            raise XacroException("No such key: '{}'".format(item))
-
-    __getitem__ = __getattr__
-
 def load_yaml(filename):
     try:
         import yaml
@@ -118,7 +104,7 @@ def load_yaml(filename):
     f = open(filename)
     oldstack = push_file(filename)
     try:
-        return YamlDictWrapper(yaml.safe_load(f))
+        return yaml.safe_load(f)
     finally:
         f.close()
         restore_filestack(oldstack)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1156,6 +1156,21 @@ class TestXacro(TestXacroCommentsIgnored):
         res = '''<a>baz</a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
+    def test_xacro_exist_required(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="non-existent.xacro"/>
+</a>'''
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
+
+    def test_xacro_exist_optional(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="non-existent.xacro" optional="True"/>
+</a>'''
+        res = '''<a></a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
     def test_macro_default_param_evaluation_order(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:macro name="foo" params="arg:=${2*foo}">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1136,6 +1136,26 @@ class TestXacro(TestXacroCommentsIgnored):
             self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
                                 res.format(tag=i))
 
+    def test_yaml_support_key_in_dict(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="bar" value="${'foo' if 'arms' in settings else 'baz'}"/>
+  ${bar}
+</a>'''
+        res = '''<a>foo</a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
+    def test_yaml_support_key_not_in_dict(self):
+        src = '''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="bar" value="${settings['foo'] if 'foo' in settings else 'baz'}"/>
+  ${bar}
+</a>'''
+        res = '''<a>baz</a>'''
+        self.assert_matches(self.quick_xacro(src), res)
+
     def test_macro_default_param_evaluation_order(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:macro name="foo" params="arg:=${2*foo}">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1136,53 +1136,6 @@ class TestXacro(TestXacroCommentsIgnored):
             self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
                                 res.format(tag=i))
 
-    def test_yaml_support_dotted(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
-  <xacro:property name="type" value="$(arg type)"/>
-  <xacro:include filename="${settings.arms[type].file}"/>
-  <xacro:call macro="${settings.arms[type].macro}"/>
-</a>'''
-        res = '''<a><{tag}/></a>'''
-        for i in ['inc1', 'inc2']:
-            self.assert_matches(self.quick_xacro(src, cli=['type:=%s' % i]),
-                                res.format(tag=i))
-
-    def test_yaml_support_dotted_key_error(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
-  <xacro:property name="bar" value="${settings.baz}"/>
-  ${bar}
-</a>'''
-        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
-
-    def test_yaml_support_dotted_arith(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
-  <xacro:property name="bar" value="${settings.arms.inc2.props.port + 1}"/>
-  ${bar}
-</a>'''
-        res = '''<a>4243</a>'''
-        self.assert_matches(self.quick_xacro(src), res)
-
-    def test_xacro_exist_required(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="non-existent.xacro"/>
-</a>'''
-        self.assertRaises(xacro.XacroException, self.quick_xacro, src)
-
-    def test_xacro_exist_optional(self):
-        src = '''
-<a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="non-existent.xacro" optional="True"/>
-</a>'''
-        res = '''<a></a>'''
-        self.assert_matches(self.quick_xacro(src), res)
-
     def test_macro_default_param_evaluation_order(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:macro name="foo" params="arg:=${2*foo}">


### PR DESCRIPTION
Removing `YamlDictWrapper`.  `YamlDictWrapper` actively breaks normal Python `dict` functionality and prevents useful functionality like checking to see if a key exists in a `dict`.  `YamlDictWrapper` intended to provide user convenience "dot accessors", but they aren't necessary.  The minor convenience of `foo['bar'].baz` instead of `foo['bar']['baz']` isn't sufficient justification for breaking other useful and valid functionality.