### PR TITLE
ROS2: Append test directory to existing AMENT_PREFIX_PATH instead of replacing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
 find_package(ament_cmake_pytest REQUIRED)
 ament_add_pytest_test(pytest .
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+  ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index:$ENV{AMENT_PREFIX_PATH}
   )
 
 add_test(NAME xacro_cmake


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

This will allow the launch testing to run on a normal setup with `launch_testing` installed in `/opt/ros/foxy/setup.bash`