### PR TITLE
Report correct filename for XML errors

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -453,14 +453,13 @@ def process_include(elt, macros, symbols, func):
             func(include, ns_macros, ns_symbols)
             included.append(include)
             import_xml_namespaces(elt.parentNode, include.attributes)
+            # restore filestack
+            restore_filestack(oldstack)
         except XacroException as e:
             if e.exc and isinstance(e.exc, IOError) and optional is True:
                 continue
             else:
                 raise
-        finally:
-            # restore filestack
-            restore_filestack(oldstack)
 
     remove_previous_comments(elt)
     # replace the include tag with the nodes of the included file(s)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -959,6 +959,12 @@ class TestXacro(TestXacroCommentsIgnored):
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:arg name="foo" default=""/>$(arg foo)</a>'''), '''<a/>''')
 
+    def test_broken_include_error_reporting(self):
+        self.assertRaises(xml.parsers.expat.ExpatError, self.quick_xacro,
+        '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+           <xacro:include filename="broken.xacro"/></a>''')
+        self.assertEqual(xacro.filestack, [None, './broken.xacro'])
+
     def test_broken_input_doesnt_create_empty_output_file(self):
         # run xacro on broken input file to make sure we don't create an
         # empty output file


### PR DESCRIPTION
Fixes #267. Looks like the correct error-location reporting was lost with #234.