### PR TITLE
Improve macro arg parsing

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -543,8 +543,11 @@ def is_valid_name(name):
     return False
 
 
-re_macro_arg = re.compile(r'''\s*([^\s:=]+?):?=(\^\|?)?((?:(?:'[^']*')?[^\s'"]*?)*)(?:\s+|$)(.*)''')
-#                           space   param    :=   ^|   <--      default      -->   space    rest
+default_value = '''\$\{.*?\}|\$\(.*?\)|(?:'.*?'|\".*?\"|[^\s'\"]+)+|'''
+re_macro_arg = re.compile(r'^\s*([^\s:=]+?)\s*:?=\s*(\^\|?)?(' + default_value + ')(?:\s+|$)(.*)')
+#                          space(   param )(   :=  )(  ^|  )(        default      )( space )(rest)
+
+
 def parse_macro_arg(s):
     """
     parse the first param spec from a macro parameter string s

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -228,8 +228,10 @@ class TestXacroFunctions(unittest.TestCase):
 
     def test_parse_macro_arg(self):
         for forward in ['', '^', '^|']:
-            defaults = ['', "f('some string','some other')", "f('a b')"]
-            if forward == '^': defaults = ['']
+            defaults = ['', "'single quoted'", '"double quoted"', '${2 * (prop_with_spaces + 1)}', '$(substitution arg)',
+                        "anything~w/o~space-'space allowed in quotes'(\"as here too\")", 'unquoted']
+            if forward == '^':
+                defaults = ['']  # default allowed allowed afer ^|
             for default in defaults:
                 seps = ['=', ':='] if forward or default else ['']
                 for sep in seps:


### PR DESCRIPTION
... supporting:
- `$(substitution args)`
- `${python expressions}`
- `'single quoting'` or `"double quoting"` of spaces

Fixes #277. @adbidwai, please review.