### PR TITLE
Expose more functions

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -205,6 +205,20 @@ def create_global_symbols():
     expose(load_yaml=load_yaml, abs_filename=abs_filename_spec, dotify=YamlDictWrapper,
            ns='xacro', deprecate_msg=deprecate_msg)
 
+    def message_adapter(f):
+        def wrapper(*args, **kwargs):
+            kwargs.update(file=sys.stderr)
+            f(*args, **kwargs)
+            return ''  # Return empty string instead of None
+        return wrapper
+
+    def fatal(*args):
+        raise XacroException(' '.join(map(str, args)))
+
+    # Expose xacro's message functions
+    expose([(f.__name__, message_adapter(f)) for f in [message, warning, error]], ns='xacro')
+    expose(fatal=fatal, ns='xacro')
+
     return result
 
 

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -152,6 +152,14 @@ def load_yaml(filename):
         all_includes.append(filename)
 
 
+def tokenize(s, sep=',; ', skip_empty=True):
+    results = re.split('[{}]'.format(sep), s)
+    if skip_empty:
+        return [item for item in results if item]
+    else:
+        return results
+
+
 # create global symbols dictionary
 # taking simple security measures to forbid access to __builtins__
 # only the very few symbols explicitly listed are allowed
@@ -217,7 +225,7 @@ def create_global_symbols():
 
     # Expose xacro's message functions
     expose([(f.__name__, message_adapter(f)) for f in [message, warning, error]], ns='xacro')
-    expose(fatal=fatal, ns='xacro')
+    expose(fatal=fatal, tokenize=tokenize, ns='xacro')
 
     return result
 

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -215,7 +215,7 @@ def create_global_symbols():
 
     def message_adapter(f):
         def wrapper(*args, **kwargs):
-            kwargs.update(file=sys.stderr)
+            kwargs.pop('file', None)  # Don't forward a file argument
             f(*args, **kwargs)
             return ''  # Return empty string instead of None
         return wrapper
@@ -223,9 +223,13 @@ def create_global_symbols():
     def fatal(*args):
         raise XacroException(' '.join(map(str, args)))
 
+    def location():
+        print_location(filestack)
+        return ''
+
     # Expose xacro's message functions
     expose([(f.__name__, message_adapter(f)) for f in [message, warning, error]], ns='xacro')
-    expose(fatal=fatal, tokenize=tokenize, ns='xacro')
+    expose(fatal=fatal, print_location=location, tokenize=tokenize, ns='xacro')
 
     return result
 

--- a/src/xacro/color.py
+++ b/src/xacro/color.py
@@ -10,8 +10,13 @@ def is_tty(stream): # taken from catkin_tools/common.py
 
 
 def colorize(msg, color, file=sys.stderr, alt_text=None):
+    try:
+        color = _ansi[color]
+    except KeyError:
+        pass
+
     if color and is_tty(file):
-        return '\033[%dm%s\033[0m' % (_ansi[color], msg)
+        return '\033[%dm%s\033[0m' % (color, msg)
     elif alt_text:
         return '%s%s' % (alt_text, msg)
     else:

--- a/test/location.xacro
+++ b/test/location.xacro
@@ -1,0 +1,1 @@
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">${xacro.print_location()}</a>

--- a/test/raise.xacro
+++ b/test/raise.xacro
@@ -1,0 +1,4 @@
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<xacro:macro name="inner">${undefined}</xacro:macro>
+	<xacro:macro name="outer"><xacro:inner/></xacro:macro>
+</a>

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -244,6 +244,18 @@ class TestXacroFunctions(unittest.TestCase):
         for ws in ['  ', ' \t ', ' \n ']:
             self.check_macro_arg(ws + 'foo' + ws + 'bar=42' + ws, 'foo', None, None, 'bar=42' + ws)
 
+    def test_tokenize(self):
+        tokens = ['ab', 'cd', 'ef']
+        for sep in [' ', ',', ';', ', ']:
+            self.assertEqual(xacro.tokenize(sep.join(tokens)), tokens)
+
+    def test_tokenize_keep_empty(self):
+        tokens = ' '.join(['ab', ' ', 'cd', 'ef'])
+        results = xacro.tokenize(tokens, sep=' ', skip_empty=False)
+        self.assertEqual(len(results), 5)  # intermediate space becomes '   ' split into 2 empty fields
+        self.assertEqual(' '.join(results), tokens)
+
+
 # base class providing some convenience functions
 class TestXacroBase(unittest.TestCase):
     def __init__(self, *args, **kwargs):

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -560,7 +560,7 @@ class TestXacro(TestXacroCommentsIgnored):
   <xacro:property name="var" value="main"/>
   <xacro:include filename="include1.xacro" ns="A"/>
   <xacro:include filename="include2.xacro" ns="B"/>
-  <xacro:A.foo/><B.foo/>
+  <xacro:A.foo/><xacro:B.foo/>
   <main var="${var}" A="${2*A.var}" B="${B.var+1}"/>
 </a>'''
         result = '''
@@ -987,10 +987,10 @@ class TestXacro(TestXacroCommentsIgnored):
         self.assert_matches(
                 self.quick_xacro('''\
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="list" value="[0, 1+1, 2]"/>
-  <xacro:property name="tuple" value="(0,1+1,2)"/>
-  <xacro:property name="dict" value="{'a':0, 'b':1+1, 'c':2}"/>
-  <a list="${list}" tuple="${tuple}" dict="${dict}"/>
+  <xacro:property name="l" value="[0, 1+1, 2]"/>
+  <xacro:property name="t" value="(0,1+1,2)"/>
+  <xacro:property name="d" value="{'a':0, 'b':1+1, 'c':2}"/>
+  <a list="${l}" tuple="${t}" dict="${d}"/>
 </a>'''),
 '''<a>
   <a list="[0, 1+1, 2]" tuple="(0,1+1,2)" dict="{'a':0, 'b':1+1, 'c':2}"/>
@@ -1000,10 +1000,10 @@ class TestXacro(TestXacroCommentsIgnored):
         self.assert_matches(
                 self.quick_xacro('''\
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="list" value="${[0, 1+1, 2]}"/>
-  <xacro:property name="tuple" value="${(0,1+1,2)}"/>
-  <xacro:property name="dic" value="${dict(a=0, b=1+1, c=2)}"/>
-  <a list="${list}" tuple="${tuple}" dict="${dic}"/>
+  <xacro:property name="l" value="${[0, 1+1, 2]}"/>
+  <xacro:property name="t" value="${(0,1+1,2)}"/>
+  <xacro:property name="d" value="${dict(a=0, b=1+1, c=2)}"/>
+  <a list="${l}" tuple="${t}" dict="${d}"/>
 </a>'''),
 '''<a>
   <a list="[0, 2, 2]" tuple="(0, 2, 2)" dict="{'a': 0, 'c': 2, 'b': 2}"/>
@@ -1130,7 +1130,6 @@ class TestXacroInorder(TestXacro):
         res = '''<a>sin</a>'''
         with capture_stderr(self.quick_xacro, src) as (result, output):
             self.assert_matches(result, res)
-            print(output)
             self.assertTrue("redefining global symbol: str" in output)
 
     def test_include_lazy(self):
@@ -1153,7 +1152,7 @@ class TestXacroInorder(TestXacro):
     <a xmlns:xacro="http://www.ros.org/xacro">
       <xacro:macro name="foo" params="file:=include1.xml"><xacro:include filename="${file}"/></xacro:macro>
       <xacro:foo/>
-      <xacro:foo file="${abs_filename('include1.xml')}"/>
+      <xacro:foo file="${xacro.abs_filename('include1.xml')}"/>
       <xacro:include filename="subdir/foo.xacro"/>
       <xacro:foo file="$(cwd)/subdir/include1.xml"/>
     </a>'''
@@ -1163,7 +1162,7 @@ class TestXacroInorder(TestXacro):
     def test_dotify(self):
       src = '''
     <a xmlns:xacro="http://www.ros.org/xacro">
-      <xacro:property name="settings" value="${dotify(dict(a=1, b=2))}"/>
+      <xacro:property name="settings" value="${xacro.dotify(dict(a=1, b=2))}"/>
       ${settings.a + settings.b}
     </a>'''
       res = '''<a>3</a>'''
@@ -1172,7 +1171,7 @@ class TestXacroInorder(TestXacro):
     def test_yaml_support(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="settings" value="${xacro.load_yaml('settings.yaml')}"/>
   <xacro:property name="type" value="$(arg type)"/>
   <xacro:include filename="${settings['arms'][type]['file']}"/>
   <xacro:call macro="${settings['arms'][type]['macro']}"/>
@@ -1185,7 +1184,7 @@ class TestXacroInorder(TestXacro):
     def test_yaml_support_dotted(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="settings" value="${xacro.load_yaml('settings.yaml')}"/>
   <xacro:property name="type" value="$(arg type)"/>
   <xacro:include filename="${settings.arms[type].file}"/>
   <xacro:call macro="${settings.arms[type].macro}"/>
@@ -1198,7 +1197,7 @@ class TestXacroInorder(TestXacro):
     def test_yaml_support_dotted_key_error(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="settings" value="${xacro.load_yaml('settings.yaml')}"/>
   <xacro:property name="bar" value="${settings.baz}"/>
   ${bar}
 </a>'''
@@ -1207,7 +1206,7 @@ class TestXacroInorder(TestXacro):
     def test_yaml_support_dotted_arith(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="settings" value="${xacro.load_yaml('settings.yaml')}"/>
   <xacro:property name="bar" value="${settings.arms.inc2.props.port + 1}"/>
   ${bar}
 </a>'''
@@ -1217,7 +1216,7 @@ class TestXacroInorder(TestXacro):
     def test_yaml_support_key_in_dict(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="settings" value="${load_yaml('settings.yaml')}"/>
+  <xacro:property name="settings" value="${xacro.load_yaml('settings.yaml')}"/>
   ${'arms' in settings} ${'baz' in settings}
 </a>'''
         res = '''<a>True False</a>'''
@@ -1226,8 +1225,8 @@ class TestXacroInorder(TestXacro):
     def test_yaml_support_list_of_x(self):
         src = '''
     <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-      <xacro:property name="list" value="${load_yaml('list.yaml')}"/>
-      ${list[0][1]} ${list[1][0]} ${list[2].a.A} ${list[2].a.B[0]} ${list[2].a.B[1]} ${list[2].b[0]}
+      <xacro:property name="l" value="${xacro.load_yaml('list.yaml')}"/>
+      ${l[0][1]} ${l[1][0]} ${l[2].a.A} ${l[2].a.B[0]} ${l[2].a.B[1]} ${l[2].b[0]}
     </a>'''
         res = '''<a>A2 B1 1 2 3 4</a>'''
         self.assert_matches(self.quick_xacro(src), res)
@@ -1235,7 +1234,7 @@ class TestXacroInorder(TestXacro):
     def test_yaml_custom_constructors(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="values" value="${load_yaml('constructors.yaml')}"/>
+  <xacro:property name="values" value="${xacro.load_yaml('constructors.yaml')}"/>
   <values a="${values.a}" b="${values.b}" c="${values.c}"/>
 </a>'''
         res = '''<a><values a="{}" b="{}" c="42"/></a>'''.format(math.pi, 0.5*math.pi)
@@ -1245,7 +1244,7 @@ class TestXacroInorder(TestXacro):
         for file in ['constructors_bad1.yaml', 'constructors_bad2.yaml']:
           src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="values" value="${{load_yaml({file})}}"/>
+  <xacro:property name="values" value="${{xacro.load_yaml({file})}}"/>
   <values a="${{values.a}}" />
 </a>'''
         self.assertRaises(xacro.XacroException, self.quick_xacro, src.format(file=file))

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1135,6 +1135,20 @@ class TestXacroInorder(TestXacro):
         super(TestXacroInorder, self).__init__(*args, **kwargs)
         self.in_order = True
 
+    def test_print_location(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+        <xacro:macro name="scope"><xacro:include filename="location.xacro"/></xacro:macro>
+        <xacro:scope/>
+        </a>'''
+        res = '''<a/>'''
+        self.quick_xacro(src)
+        with capture_stderr(self.quick_xacro, src) as (result, output):
+            self.assert_matches(result, res)
+            self.assertTrue(output == '''when instantiating macro: scope (???)
+in file: ./location.xacro
+included from: string
+''')
+
     def test_redefine_global_symbol(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
         <xacro:property name="str" value="sin"/>

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1108,6 +1108,15 @@ class TestXacro(TestXacroCommentsIgnored):
         res='''<a><b/></a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
+    def test_message_functions(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">${{xacro.{f}('colored', 'text', 2, 3.14)}}</a>'''
+        res = '''<a/>'''
+        for f in ['message', 'warning', 'error']:
+          with capture_stderr(self.quick_xacro, src.format(f=f)) as (result, output):
+              self.assert_matches(result, res)
+              self.assertTrue('colored text 2 3.14' in output)
+        self.assertRaises(xacro.XacroException, self.quick_xacro, src.format(f='fatal'))
+
 # test class for in-order processing
 class TestXacroInorder(TestXacro):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Before exposing even more useful python functions as global symbols, this PR first cleans up the definition of `global_symbols`.
To correctly report the macro call hierarchy via the newly exposed `print_location()` function, I also had to rework the handling of the file and macro stack, which is now hopefully much cleaner.