### PR TITLE
Allow greedy property evaluation

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -683,7 +683,7 @@ def grab_property(elt, table):
     assert(elt.tagName in ['property', 'xacro:property'])
     remove_previous_comments(elt)
 
-    name, value, default, scope = check_attrs(elt, ['name'], ['value', 'default', 'scope'])
+    name, value, default, scope, greedy = check_attrs(elt, ['name'], ['value', 'default', 'scope', 'greedy'])
     if not is_valid_name(name):
         raise XacroException('Property names must be valid python identifiers: ' + name)
     if name.startswith('__'):
@@ -718,7 +718,7 @@ def grab_property(elt, table):
             return # cannot store the value, no reason to evaluate it
     else:
         target_table = table
-        unevaluated = True
+        unevaluated = not get_boolean_value(eval_text(greedy or 'false', table), greedy)
 
     if not unevaluated and isinstance(value, _basestr):
         value = eval_text(value, table)

--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -357,8 +357,9 @@ class Table(object):
         # lazy evaluation
         if key in self.unevaluated:
             if key in self.recursive:
-                raise XacroException("recursive variable definition: %s" %
-                                     " -> ".join(self.recursive + [key]))
+                raise XacroException('circular variable definition: {}\n'
+                                     'Consider disabling lazy evaluation via lazy_eval="false"'
+                                     .format(" -> ".join(self.recursive + [key])))
             self.recursive.append(key)
             self.table[key] = self._eval_literal(eval_text(self.table[key], self))
             self.unevaluated.remove(key)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -793,13 +793,16 @@ class TestXacro(TestXacroCommentsIgnored):
 </robot>''')
 
     def test_recursive_definition(self):
-        self.assertRaises(xacro.XacroException,
-                          self.quick_xacro, '''\
+        with self.assertRaises(xacro.XacroException) as cm:
+            self.quick_xacro('''
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="a" value="${a2}"/>
   <xacro:property name="a2" value="${2*a}"/>
   <a doubled="${a2}"/>
 </robot>''')
+        msg = str(cm.exception)
+        self.assertTrue(msg.startswith('circular variable definition: a2 -> a -> a2\n'
+                                       'Consider disabling lazy evaluation via lazy_eval="false"'))
 
     def test_greedy_property_evaluation(self):
         src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -801,6 +801,13 @@ class TestXacro(TestXacroCommentsIgnored):
   <a doubled="${a2}"/>
 </robot>''')
 
+    def test_greedy_property_evaluation(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+        <xacro:property name="s" value="AbCd"/>
+        <xacro:property name="s" value="${s.lower()}" lazy_eval="false"/>
+        ${s}</a>'''
+        self.assert_matches(self.quick_xacro(src), '<a>abcd</a>')
+
     def test_multiple_recursive_evaluation(self):
         self.assert_matches(self.quick_xacro('''\
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">


### PR DESCRIPTION
This can be used, to redefine a property from its previous value, e.g. for normalization:
```xml
<xacro:property name="prop" value="${prop.lower()}" greedy="true"/>
```
Without this option, due to lazy evaluation, it would be an attempt to recursively evaluate the property.
@gavanderhoorn + @guihomework: Please comment, particularly about the attribute name. Alternatively, we could use `lazy="false"`.

**UPDATE:** I decided for the attribute `lazy_eval="false"` now.

### TODO
- [x] Add unit tests
- [x] Point out the new attribute in case of a 1-hop circular evaluation.