### PR TITLE
Fix handling of xml namespaces imported via xacro:include in a macro

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -842,8 +842,11 @@ def handle_macro_call(node, macros, symbols):
             e.macros = [m]
         raise
 
-    # Replaces the macro node with the expansion
+    # Remove any comments directly before the macro call
     remove_previous_comments(node)
+    # Lift all namespace attributes from the expanded body node to node's parent
+    import_xml_namespaces(node.parentNode, body.attributes)
+    # Replaces the macro node with the expansion
     replace_node(node, by=body, content_only=True)
     return True
 

--- a/test/namespace.xml
+++ b/test/namespace.xml
@@ -1,0 +1,1 @@
+<a xmlns:xacro="http://www.ros.org/xacro" xmlns:b="http://www.ros.org/b" />

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1108,6 +1108,16 @@ class TestXacro(TestXacroCommentsIgnored):
         res='''<a><b/></a>'''
         self.assert_matches(self.quick_xacro(src), res)
 
+    def test_xml_namespace_lifting(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro" xmlns:a="http://www.ros.org/a">
+  <xacro:macro name="test">
+    <xacro:include filename="namespace.xml"></xacro:include>
+  </xacro:macro>
+  <xacro:test />
+</a>'''
+        res = '''<a xmlns:a="http://www.ros.org/a" xmlns:b="http://www.ros.org/b" />'''
+        self.assert_matches(self.quick_xacro(src), res)
+
 # test class for in-order processing
 class TestXacroInorder(TestXacro):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Namespace declarations are lifted to the parent of the include node.
In case of a macro instantiation, this is a dummy node whose contents are kept but which is removed itself.
Hence, before removing the dummy node, we need to lift any namespace definitions.