### PR TITLE
Allow removal of properties

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -759,8 +759,9 @@ def grab_properties(elt, table):
         next = next_sibling_element(elt)
         if elt.tagName in ['property', 'xacro:property'] \
                 and check_deprecated_tag(elt.tagName):
-            if "default" in elt.attributes.keys():
-                raise XacroException('default property value supported with in-order option only')
+            for name in ['default', 'remove']:
+                if name in elt.attributes.keys():
+                    raise XacroException('Property attribute {} supported with in-order option only'.format(name))
             grab_property(elt, table)
         else:
             grab_properties(elt, table)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1477,6 +1477,14 @@ ${u'🍔' * how_many}
         self.assertRaises(xacro.XacroException, self.quick_xacro, '<a>a$(</a>')
         self.assertRaises(xacro.XacroException, self.quick_xacro, '<a>$(b</a>')
 
+    def test_remove_property(self):
+        src = '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<xacro:property name="p" default="1st" />
+	<xacro:property name="p" remove="true" />
+	<xacro:property name="p" default="2nd" />
+	${p}</a>'''
+        self.assert_matches(self.quick_xacro(src), '<a>2nd</a>')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1481,7 +1481,7 @@ ${u'🍔' * how_many}
         template = '<a xmlns:xacro="http://www.ros.org/wiki/xacro"><xacro:property name="p" {} /> ${{p}} </a>'
 
         def check(attributes, expected, **kwargs):
-            with self.subTest(msg='Checking ' + attributes):
+            # with self.subTest(msg='Checking ' + attributes):
                 with self.assertRaises(xacro.XacroException) as cm:
                     self.quick_xacro(template.format(attributes), **kwargs)
                 self.assertEqual(str(cm.exception), expected)


### PR DESCRIPTION
With `inorder` processing, it might be beneficial to remove a previously defined property.