### PR TITLE
`xacro:loop` macro

### DIFF
--- a/examples/loop.xacro
+++ b/examples/loop.xacro
@@ -14,7 +14,7 @@
 
 	<xacro:loop items="${items}">
 		<body>
-			<item>item</item>
+			<item>item: ${item}</item>
 		</body>
 	</xacro:loop>
 </macro_library>

--- a/examples/loop.xacro
+++ b/examples/loop.xacro
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<macro_library xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<xacro:macro name="loop" params="items **body:=^">
+		<xacro:if value="${items}">
+			<!-- pop first item from list -->
+			<xacro:property name="item" value="${items[0]}"/>
+			<xacro:insert_block name="body" />
+			<!-- recursively call myself -->
+			<xacro:loop items="${items[1:]}"/>
+		</xacro:if>
+	</xacro:macro>
+
+	<xacro:property name="items" value="${python.range(5)}" />
+
+	<xacro:loop items="${items}">
+		<body>
+			<item>item</item>
+		</body>
+	</xacro:loop>
+</macro_library>


### PR DESCRIPTION
As pointed out by @captain-yoshi in https://github.com/ros/xacro/issues/280#issuecomment-912861096 xacro can be used to realize loops:
```xml
<robot name="loop" xmlns:xacro="http://www.ros.org/wiki/xacro">
	<xacro:macro name="loop" params="items:=^">
		<xacro:if value="${items}">
			<!-- pop first item from list -->
			<xacro:property name="item" value="${items.pop(0)}"/>

			<item>${item}</item>

			<!-- recursively call myself -->
			<xacro:loop/>
		</xacro:if>
	</xacro:macro>
	<xacro:loop items="${[1,2,3,4,5]}"/>
</robot>
```

However, it would be even nicer if we could define a generic `loop` macro like this:
```xml
<xacro:macro name="loop" params="items **body:=^">
	<xacro:if value="${items}">
		<!-- pop first item from list -->
		<xacro:property name="item" value="${items[0]}"/>
		<xacro:insert_block name="body" />
		<!-- recursively call myself -->
		<xacro:loop items="${items[1:]}"/>
	</xacro:if>
</xacro:macro>
```
and then just call it with an arbitrary body:
```xml
<xacro:loop items="${python.range(5)}">
	<body>
		<item>${item}</item>
	</body>
</xacro:loop>
```

The attached commits are two (failed) attempts to achieve this. The culprit is the recursive handling of nested macros, which seems to be required to due lazy evaluation of the first generation of xacro.