### PR TITLE
Fix resolving of macros declared and called in/from a namespace

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -857,7 +857,7 @@ def resolve_macro(fullname, macros):
         # traverse namespaces to actual macros dict
         for ns in namespaces:
             macros = macros[ns]
-        return macros[name]
+        return macros, macros[name]
 
     # try fullname and (namespaces, name) in this order
     try:
@@ -878,7 +878,7 @@ def handle_macro_call(node, macros, symbols):
         return False
 
     try:
-        m = resolve_macro(name, macros)
+        macros, m = resolve_macro(name, macros)
         if name is node.tagName:  # no xacro prefix provided?
             deprecated_tag(name)
         body = m.body.cloneNode(deep=True)

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -268,9 +268,9 @@ class TestXacroFunctions(unittest.TestCase):
         macros = dict(content)
         macros.update(ns1=ns1)
 
-        self.assertEqual(xacro.resolve_macro('simple', macros), 'simple')
-        self.assertEqual(xacro.resolve_macro('ns1.simple', macros), 'simple1')
-        self.assertEqual(xacro.resolve_macro('ns1.ns2.simple', macros), 'simple2')
+        self.assertEqual(xacro.resolve_macro('simple', macros), (macros, 'simple'))
+        self.assertEqual(xacro.resolve_macro('ns1.simple', macros), (ns1, 'simple1'))
+        self.assertEqual(xacro.resolve_macro('ns1.ns2.simple', macros), (ns2, 'simple2'))
 
     def check_macro_arg(self, s, param, forward, default, rest):
         p, v, r = xacro.parse_macro_arg(s)


### PR DESCRIPTION
Given two macros, declared in a namespace-included file,
from outside they can only be accessed using the namespace prefix.
However, when calling one macro from the other (within the namespace),
the namespace prefix shouldn't be required anymore (it's not even known).
To fix this issue, the macros dict needs to be updated during resolution.
Fixes #296.

Note: macros declared outside the namespace will not be accessible anymore!