### PR TITLE
Updated error type in YamlDictWrapper

### DIFF
--- a/src/xacro/__init__.py
+++ b/src/xacro/__init__.py
@@ -110,7 +110,7 @@ class YamlDictWrapper(dict):
         try:
             return YamlListWrapper.wrap(super(YamlDictWrapper, self).__getitem__(item))
         except KeyError:
-            raise XacroException("No such key: '{}'".format(item))
+            raise AttributeError("'YamlDictWrapper' object has no attribute '{}'".format(item))
 
     __getitem__ = __getattr__
 

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1514,6 +1514,11 @@ included from: string
 </a>'''
         self.assertRaises(xacro.XacroException, self.quick_xacro, src.format(file=file))
 
+    def test_yaml_hasattr_support(self):
+        yaml = xacro.load_yaml('settings.yaml')
+        self.assertTrue(hasattr(yaml, 'arms'))
+        self.assertFalse(hasattr(yaml, 'this_key_does_not_exist'))
+
     def test_xacro_exist_required(self):
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">


### PR DESCRIPTION
This allows the `hasattr` function to work properly.

Also changed the error message to be more similar to the standard error message for attribute access.