### PR TITLE
HACK: Allow resolution of current project's path at build time

### DIFF
--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -46,7 +46,6 @@ function(xacro_add_xacro_file input)
       message(FATAL_ERROR "no <output> specified for: " ${input})
     endif()
   endif()
-  # message(STATUS "output: ${output}")
 
   ## determine absolute output target location
   if(IS_ABSOLUTE ${output})
@@ -54,7 +53,6 @@ function(xacro_add_xacro_file input)
   else()
     set(abs_output ${CMAKE_CURRENT_BINARY_DIR}/${output})
   endif()
-  # message(STATUS "abs_output: ${abs_output}")
 
   ## export abs_output to parent scope in variable ${_XACRO_OUTPUT}
   if(NOT _XACRO_OUTPUT)
@@ -132,7 +130,6 @@ function(xacro_add_files)
 
   # have INSTALL option, but no TARGET: fallback to default target
   if(_XACRO_INSTALL AND NOT _XACRO_TARGET)
-    # message(STATUS "xacro: no TARGET specified, using default")
     set(_XACRO_TARGET _xacro_auto_generate)
   endif()
 

--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -77,9 +77,16 @@ ${_xacro_err}")
 
   separate_arguments(_xacro_deps_result)
 
+  ## HACK: ament package resolution doesn't work at build time yet
+  # - Augment AMENT_PREFIX_PATH to include ${PROJECT_BINARY_DIR}/ament_cmake_index
+  # - Create a symlink from there to the actual source directory to find source files
+  set(PROJECT_BUILD_INDEX "${PROJECT_BINARY_DIR}/ament_cmake_index")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BUILD_INDEX}/share")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}" "${PROJECT_BUILD_INDEX}/share/${PROJECT_NAME}")
+
   ## command to actually call xacro
   add_custom_command(OUTPUT ${output}
-    COMMAND xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
+    COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
     DEPENDS ${input} ${_xacro_deps_result} ${_XACRO_DEPENDS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "xacro: generating ${output} from ${input}"

--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -85,8 +85,9 @@ ${_xacro_err}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}" "${PROJECT_BUILD_INDEX}/share/${PROJECT_NAME}")
 
   ## command to actually call xacro
-  add_custom_command(OUTPUT ${output}
-    COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
+  list(JOIN AMENT_PREFIX_PATH ":" AMENT_PREFIX_PATH_ENV) # format as colon-separated list
+  add_custom_command(OUTPUT ${abs_output}
+    COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH_ENV}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
     DEPENDS ${input} ${_xacro_deps_result} ${_XACRO_DEPENDS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "xacro: generating ${output} from ${input}"


### PR DESCRIPTION
The cmake function `xacro_add_files` runs `xacro` at build time. To resolve `$(find current_package)` within xacro files, `xacro` relies on a properly configured ament package index. However, this index is only created after building, during installation.
By manually prepending `AMENT_PREFIX_PATH` with the current project's `ament_cmake_index` in the `build` folder _and_ symlinking the source folder into the corresponding `share` folder, I was able to work around this shortcoming. However, a fix in https://github.com/ament/ament_cmake would be definitely better.

Partially fixes #325.
Resolution of packages during xacro-dependency lookup still doesn't work.