### PR TITLE
Add support for devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# Set base image
+ARG ROS_DISTRO=humble
+FROM ros:${ROS_DISTRO}-ros-base
+
+# Arguments
+ARG GID=1000
+ARG UID=1000
+
+# Install some dependencies packages
+RUN apt update -q \
+ && apt upgrade -q -y \
+ && apt install -y gdb python3-pip software-properties-common sudo --no-install-recommends \
+ && apt clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add the 'dev' user
+RUN groupadd -g ${GID} dev \
+ && useradd -lm -u ${UID} -g dev -s /bin/bash dev \
+ && echo "dev ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER dev
+
+# Create workspace so that user 'dev' own this directory
+RUN mkdir -p /home/dev/ros_ws/src \
+ && echo 'source /opt/ros/'${ROS_DISTRO}'/setup.bash' >> /home/dev/.bashrc \
+ && echo 'source /home/dev/ros_ws/install/setup.bash' >> /home/dev/.bashrc
+
+WORKDIR /home/dev/ros_ws
+CMD ["bash"]

--- a/.devcontainer/foxy/devcontainer.json
+++ b/.devcontainer/foxy/devcontainer.json
@@ -1,0 +1,42 @@
+{
+    "name": "ROS 2 Foxy Development Container",
+    "privileged": true,
+    "remoteUser": "dev",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "../..",
+        "args": {
+            "ROS_DISTRO": "foxy",
+            "GID": "1000",
+            "UID": "1000"
+        }
+    },
+    "workspaceFolder": "/home/dev/ros_ws",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/dev/ros_ws/src,type=bind",
+    "runArgs": [
+        "--net=host",
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "charliermarsh.ruff",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-iot.vscode-ros",
+                "smilerobotics.urdf",
+                "redhat.vscode-xml",
+                "redhat.vscode-yaml",
+                "yzhang.markdown-all-in-one",
+            ],
+            "settings": {
+                "files.associations": {
+                    "*.rviz": "yaml",
+                    "*.srdf": "xml",
+                    "*.urdf": "xml",
+                    "*.xacro": "xml"
+                }
+            }
+        }
+    },
+    "postCreateCommand": "src/.devcontainer/post-create.sh"
+}

--- a/.devcontainer/humble/devcontainer.json
+++ b/.devcontainer/humble/devcontainer.json
@@ -1,0 +1,42 @@
+{
+    "name": "ROS 2 Humble Development Container",
+    "privileged": true,
+    "remoteUser": "dev",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "../..",
+        "args": {
+            "ROS_DISTRO": "humble",
+            "GID": "1000",
+            "UID": "1000"
+        }
+    },
+    "workspaceFolder": "/home/dev/ros_ws",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/dev/ros_ws/src,type=bind",
+    "runArgs": [
+        "--net=host",
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "charliermarsh.ruff",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-iot.vscode-ros",
+                "smilerobotics.urdf",
+                "redhat.vscode-xml",
+                "redhat.vscode-yaml",
+                "yzhang.markdown-all-in-one",
+            ],
+            "settings": {
+                "files.associations": {
+                    "*.rviz": "yaml",
+                    "*.srdf": "xml",
+                    "*.urdf": "xml",
+                    "*.xacro": "xml"
+                }
+            }
+        }
+    },
+    "postCreateCommand": "src/.devcontainer/post-create.sh"
+}

--- a/.devcontainer/iron/devcontainer.json
+++ b/.devcontainer/iron/devcontainer.json
@@ -1,0 +1,42 @@
+{
+    "name": "ROS 2 Iron Development Container",
+    "privileged": true,
+    "remoteUser": "dev",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "../..",
+        "args": {
+            "ROS_DISTRO": "iron",
+            "GID": "1000",
+            "UID": "1000"
+        }
+    },
+    "workspaceFolder": "/home/dev/ros_ws",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/dev/ros_ws/src,type=bind",
+    "runArgs": [
+        "--net=host",
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "charliermarsh.ruff",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-iot.vscode-ros",
+                "smilerobotics.urdf",
+                "redhat.vscode-xml",
+                "redhat.vscode-yaml",
+                "yzhang.markdown-all-in-one",
+            ],
+            "settings": {
+                "files.associations": {
+                    "*.rviz": "yaml",
+                    "*.srdf": "xml",
+                    "*.urdf": "xml",
+                    "*.xacro": "xml"
+                }
+            }
+        }
+    },
+    "postCreateCommand": "src/.devcontainer/post-create.sh"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+rosdep update
+sudo rosdep install --from-paths src --ignore-src -y
+
+sudo pip install pre-commit
+cd src && pre-commit install

--- a/.devcontainer/rolling/devcontainer.json
+++ b/.devcontainer/rolling/devcontainer.json
@@ -1,0 +1,42 @@
+{
+    "name": "ROS 2 Rolling Development Container",
+    "privileged": true,
+    "remoteUser": "dev",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "../..",
+        "args": {
+            "ROS_DISTRO": "rolling",
+            "GID": "1000",
+            "UID": "1000"
+        }
+    },
+    "workspaceFolder": "/home/dev/ros_ws",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/dev/ros_ws/src,type=bind",
+    "runArgs": [
+        "--net=host",
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "charliermarsh.ruff",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-iot.vscode-ros",
+                "smilerobotics.urdf",
+                "redhat.vscode-xml",
+                "redhat.vscode-yaml",
+                "yzhang.markdown-all-in-one",
+            ],
+            "settings": {
+                "files.associations": {
+                    "*.rviz": "yaml",
+                    "*.srdf": "xml",
+                    "*.urdf": "xml",
+                    "*.xacro": "xml"
+                }
+            }
+        }
+    },
+    "postCreateCommand": "src/.devcontainer/post-create.sh"
+}


### PR DESCRIPTION
Hi!

I found myself using `xacro` quite a lot recently and I wanted to try to add some features as a mean to get familiar with its inner working. One way to make it easier to develop is to use [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers), so I created some that works for recent ROS 2 distros. It can probably be improved, but I think this is a good starting point.

Let me know what you think!