### PR TITLE
Adding more unit tags for yaml files 

### DIFF
--- a/test/constructors.yaml
+++ b/test/constructors.yaml
@@ -1,3 +1,9 @@
-a: !degrees 2*90
-b: !radians 0.5*pi
-c: 42
+no_tag: 42
+angles:
+  - !radians pi
+  - !degrees 2*90
+lengths:
+  - !meters 5.0*5.0
+  - !millimeters 25.0*1000.0
+  - !foot 25.0/0.3048
+  - !inches 25.0/0.0254

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1500,9 +1500,9 @@ included from: string
         src = '''
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="values" value="${xacro.load_yaml('constructors.yaml')}"/>
-  <values a="${values.a}" b="${values.b}" c="${values.c}"/>
+  <values no_tag="${values.no_tag}" angles="${values.angles}" lengths="${values.lengths}"/>
 </a>'''
-        res = '''<a><values a="{}" b="{}" c="42"/></a>'''.format(math.pi, 0.5*math.pi)
+        res = '''<a><values no_tag="42" angles="{}" lengths="{}"/></a>'''.format([math.pi]*5, [25.0]*9)
         self.assert_matches(self.quick_xacro(src), res)
 
     def test_yaml_custom_constructors_illegal_expr(self):

--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1502,7 +1502,7 @@ included from: string
   <xacro:property name="values" value="${xacro.load_yaml('constructors.yaml')}"/>
   <values no_tag="${values.no_tag}" angles="${values.angles}" lengths="${values.lengths}"/>
 </a>'''
-        res = '''<a><values no_tag="42" angles="{}" lengths="{}"/></a>'''.format([math.pi]*5, [25.0]*9)
+        res = '''<a><values no_tag="42" angles="{}" lengths="{}"/></a>'''.format([math.pi]*2, [25.0]*4)
         self.assert_matches(self.quick_xacro(src), res)
 
     def test_yaml_custom_constructors_illegal_expr(self):


### PR DESCRIPTION
Hi!

I was browsing to the code and found that tags such as `!degrees` or `!radians` can be used to set a certain value as a certain unit. I think this is great! I expended this feature to include other units such as `!meters`, `!turns`, `!inches` or `!foot`.

I also adapted the tests to include these new units.

Let me know what you think! 