### PR TITLE
Escape regexes using raw strings.

### DIFF
--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -555,8 +555,8 @@ def is_valid_name(name):
     return False
 
 
-default_value = '''\$\{.*?\}|\$\(.*?\)|(?:'.*?'|\".*?\"|[^\s'\"]+)+|'''
-re_macro_arg = re.compile(r'^\s*([^\s:=]+?)\s*:?=\s*(\^\|?)?(' + default_value + ')(?:\s+|$)(.*)')
+default_value = r'''\$\{.*?\}|\$\(.*?\)|(?:'.*?'|\".*?\"|[^\s'\"]+)+|'''
+re_macro_arg = re.compile(r'^\s*([^\s:=]+?)\s*:?=\s*(\^\|?)?(' + default_value + r')(?:\s+|$)(.*)')
 #                          space(   param )(   :=  )(  ^|  )(        default      )( space )(rest)
 
 


### PR DESCRIPTION
This fixes some warnings about invalid escape sequences, which are indeed not intended to be interpreted as escape sequences but rather as regex sequences.