### PR TITLE
Resolve $(find ...) as a result of a substitution argument

### DIFF
--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -320,6 +320,11 @@ def resolve_args(arg_str, context=None, filename=None):
         'find': _find,
     }
     resolved = _resolve_args(arg_str, context, commands)
+    # then resolve 'find' as it requires the subsequent path to be expanded already
+    commands = {
+        "find": _find,
+    }
+    resolved = _resolve_args(resolved, context, commands)
     return resolved
 
 


### PR DESCRIPTION
Fixes #338
The implementation of substitutions_args introduced in [7310f9a](https://github.com/ros/xacro/pull/213/commits/7310f9a1fb4fa9db11b60c6dced6b255c265229e) as part of #213 was missing the second call to resolve `$(find ...)` arguments.