### PR TITLE
Using substitution args without ROS

### DIFF
--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -285,14 +285,14 @@ def eval_extension(s):
     if s == '$(cwd)':
         return os.getcwd()
     try:
-        from .substitution_args import resolve_args, ArgException, PackageNotFoundError
+        from .substitution_args import resolve_args, ArgException
         return resolve_args(s, context=substitution_args_context)
     except ImportError as e:
         raise XacroException("substitution args not supported: ", exc=e)
     except ArgException as e:
         raise XacroException("Undefined substitution argument", exc=e)
-    except PackageNotFoundError as e:
-        raise XacroException("package not found:", exc=e)
+    except Exception as e:
+        raise XacroException(f"Argument resolution failed: exception={type(e)}: {e}", exc=e)
 
 
 class Table(dict):

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -292,7 +292,7 @@ def eval_extension(s):
     except ArgException as e:
         raise XacroException("Undefined substitution argument", exc=e)
     except Exception as e:
-        raise XacroException(f"Argument resolution failed: exception={type(e)}: {e}", exc=e)
+        raise XacroException(f"{type(e)}: {e}", exc=e)
 
 
 class Table(dict):

--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -137,7 +137,7 @@ def _dirname(resolved, a, args, context):
 
 
 def _eval_find(pkg):
-    from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
+    from ament_index_python.packages import get_package_share_directory
     return get_package_share_directory(pkg)
 
 

--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -41,7 +41,6 @@ import math
 import os
 import yaml
 
-from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
 from io import StringIO
 
 
@@ -138,6 +137,7 @@ def _dirname(resolved, a, args, context):
 
 
 def _eval_find(pkg):
+    from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
     return get_package_share_directory(pkg)
 
 


### PR DESCRIPTION
Hi, I have been trying to use xacro without ROS, installing directly via pip, as was discussed in [issue 329](https://github.com/ros/xacro/pull/329). However, the current solution still does not allow to use substitution args when it is possible.
Conditionally importing substitution_args at [line 288](https://github.com/ros/xacro/blob/7231b8bd7a7c8227d2234702e20fb49c598306c0/xacro/__init__.py#L288) only allows to use xacro without ROS if no substitution args are used at all. This because ament_index_python fails to import.
Moving the import of ament_index_python in _eval_find() at [line 140](https://github.com/ros/xacro/blob/7231b8bd7a7c8227d2234702e20fb49c598306c0/xacro/substitution_args.py#L140) would allow to use all substitution args except for find, which I believe is quite reasonable in a situation in which ros is not available.
I implemented this and it seems to work nice.