### PR TITLE
bazel: remove version number from MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,6 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_python", version = "0.40.0")
 
 PYTHON_VERSIONS = [
-    "3.8",
     "3.9",
     "3.10",
     "3.11",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,4 @@
-module(
-    name = "xacro",
-    version = "2.0.11",
-)
+module(name = "xacro")
 
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")


### PR DESCRIPTION
This is unneeded and injected at the central registry.
This helps eliminate maintainer churn around keeping this in sync.

Replaces: #355 