### PR TITLE
Set AMENT_PREFIX_PATH to $ENV{AMENT_PREFIX_PATH) in xacro-extras.cmake

### DIFF
--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -83,10 +83,8 @@ ${_xacro_err}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}" "${PROJECT_BUILD_INDEX}/share/${PROJECT_NAME}")
 
   ## command to actually call xacro
-  set(AMENT_PREFIX_PATH $ENV{AMENT_PREFIX_PATH})
-  list(JOIN AMENT_PREFIX_PATH ":" AMENT_PREFIX_PATH_ENV) # format as colon-separated list
   add_custom_command(OUTPUT ${abs_output}
-    COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH_ENV}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
+    COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:$ENV{AMENT_PREFIX_PATH}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
     DEPENDS ${input} ${_xacro_deps_result} ${_XACRO_DEPENDS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "xacro: generating ${output} from ${input}"

--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -83,6 +83,7 @@ ${_xacro_err}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}" "${PROJECT_BUILD_INDEX}/share/${PROJECT_NAME}")
 
   ## command to actually call xacro
+  set(AMENT_PREFIX_PATH $ENV{AMENT_PREFIX_PATH})
   list(JOIN AMENT_PREFIX_PATH ":" AMENT_PREFIX_PATH_ENV) # format as colon-separated list
   add_custom_command(OUTPUT ${abs_output}
     COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH_ENV}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}


### PR DESCRIPTION
I was having an issue where I have `derivative_robot_description` referencing xacro files from `original_robot_description` which refer to `package://original_robot_description`.

I am also using xacro-extras.cmake to generate urdf files on build from *.urdf.xacro files.

Upon building, I would encounter this error:

```
<class 'ament_index_python.packages.PackageNotFoundError'>: "package 'original_robot_description' not found, searching: ['/path/to/ws/build/derivative_robot_description/ament_cmake_index']" "package 'original_robot_description' not found, searching: ['/path/to/ws/build/derivative_robot_description/ament_cmake_index']"
```

Upon investigating the colcon build logs, I found that `list(JOIN AMENT_PREFIX_PATH ":" AMENT_PREFIX_PATH_ENV)` was not actually populating at all, and only `PROJECT_BUILD_INDEX` was doing anything in `COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH_ENV}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}`.

This change sets AMENT_PREFIX_PATH to $ENV{AMENT_PREFIX_PATH} and fixes the build issue.
