### PR TITLE
Use Label() to support different repo_name

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -96,7 +96,7 @@ xacro_file = rule(
         "arguments": attr.string_dict(),
         "deps": attr.label_list(providers = [XacroInfo]),
         "_xacro": attr.label(
-            default = "@xacro//:xacro",
+            default = Label("//:xacro"),
             cfg = "host",
             executable = True,
         ),


### PR DESCRIPTION
Resolve `xacro` label correctly when used with a different `repo_name`. This can be done by using `Label()` to resolve the label relative to the `.bzl` file instead of relative to the `BUILD` file where the macro is called.