### PR TITLE
Remote extra doc string spacing

### DIFF
--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -299,7 +299,6 @@ def resolve_args(arg_str, context=None, filename=None):
         If no context is provided, a new one will be created for each call. Values for the 'arg'
         context should be stored as a dictionary in the 'arg' key.
     @type  context: dict
-
     @return str: arg_str with substitution args resolved
     @rtype:  str
     @raise SubstitutionException: if there is an error resolving substitution args


### PR DESCRIPTION
There's warnings in the doc build: https://build.ros2.org/view/Kdoc/job/Kdoc__xacro__ubuntu_noble_amd64


```
17:01:28 # BEGIN SECTION: Look for warnings
17:01:28 Found 2 warnings:
17:01:28 
17:01:28 - /tmp/ws/src/xacro/xacro/substitution_args.py:docstring of xacro.substitution_args.resolve_args:5: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
17:01:28 
17:01:28 - /tmp/ws/src/xacro/xacro/substitution_args.py:docstring of xacro.substitution_args.resolve_args:9: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
17:01:28 
17:01:28 Marking build as unstable
17:01:28 # END SECTION
```