### PR TITLE
Change `cfg` from `host` to `exec`

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -97,7 +97,7 @@ xacro_file = rule(
         "deps": attr.label_list(providers = [XacroInfo]),
         "_xacro": attr.label(
             default = Label("//:xacro"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
     },


### PR DESCRIPTION
Otherwise, this fails when flipping [`--incompatible_disable_starlark_host_transitions`](https://github.com/bazelbuild/bazel/issues/17032).