### PR TITLE
fix(substitution_args.py): _resolve_args() not finding commands

### DIFF
--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -39,6 +39,7 @@ This file has been modified from ros_comm/tools/roslaunch/src/roslaunch/substitu
 
 import math
 import os
+import shlex
 import yaml
 
 from io import StringIO
@@ -332,10 +333,10 @@ def _resolve_args(arg_str, context, commands):
     valid = ['find', 'env', 'optenv', 'dirname', 'arg']
     resolved = arg_str
     for a in _collect_args(arg_str):
-        splits = [s for s in a.split(' ') if s]
-        if not splits[0] in valid:
+        splits = shlex.split(a)
+        if splits[0] not in valid:
             raise SubstitutionException('Unknown substitution command [%s]. '
-                                        'Valid commands are %s' % (a, valid))
+                                        'Valid commands are %s' % (splits[0], valid))
         command = splits[0]
         args = splits[1:]
         if command in commands:

--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -39,7 +39,6 @@ This file has been modified from ros_comm/tools/roslaunch/src/roslaunch/substitu
 
 import math
 import os
-import shlex
 import yaml
 
 from io import StringIO
@@ -336,7 +335,7 @@ def _resolve_args(arg_str, context, commands):
         splits = [s for s in a.split() if s]
         if splits[0] not in valid:
             raise SubstitutionException('Unknown substitution command [%s]. '
-                                        'Valid commands are %s' % (splits[0], valid))
+                                        'Valid commands are %s' % (a, valid))
         command = splits[0]
         args = splits[1:]
         if command in commands:

--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -333,11 +333,11 @@ def _resolve_args(arg_str, context, commands):
     valid = ['find', 'env', 'optenv', 'dirname', 'arg']
     resolved = arg_str
     for a in _collect_args(arg_str):
-        splits = shlex.split(a)
-        if splits[0] not in valid:
+        splits = [s for s in a.split(' ') if s]
+        if splits[0].strip() not in valid:
             raise SubstitutionException('Unknown substitution command [%s]. '
                                         'Valid commands are %s' % (splits[0], valid))
-        command = splits[0]
+        command = splits[0].strip()
         args = splits[1:]
         if command in commands:
             resolved = commands[command](resolved, a, args, context)

--- a/xacro/substitution_args.py
+++ b/xacro/substitution_args.py
@@ -333,11 +333,11 @@ def _resolve_args(arg_str, context, commands):
     valid = ['find', 'env', 'optenv', 'dirname', 'arg']
     resolved = arg_str
     for a in _collect_args(arg_str):
-        splits = [s for s in a.split(' ') if s]
-        if splits[0].strip() not in valid:
+        splits = [s for s in a.split() if s]
+        if splits[0] not in valid:
             raise SubstitutionException('Unknown substitution command [%s]. '
                                         'Valid commands are %s' % (splits[0], valid))
-        command = splits[0].strip()
+        command = splits[0]
         args = splits[1:]
         if command in commands:
             resolved = commands[command](resolved, a, args, context)


### PR DESCRIPTION
The below wasn't working for me; replacing the custom split logic in `_resolve_args()` with `shlex` seems to do the trick.

```xml
  <xacro:include filename="$(find some_package)/description/some.urdf.xacro" />
```

Error log:
```bash
Captured stderr output: error: <class 'xacro.substitution_args.SubstitutionException'>: Unknown substitution command [find some_package]. Valid commands are ['find', 'env', 'optenv', 'dirname', 'arg']
```