### PR TITLE
feat(args): Allow specifying dynamic arg

### DIFF
--- a/test/test_xacro.py
+++ b/test/test_xacro.py
@@ -1110,6 +1110,34 @@ class TestXacro(TestXacroCommentsIgnored):
 <a xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:arg name="foo" default="bar"/>${xacro.arg('foo')}</a>'''), '<a>bar</a>')
 
+    def test_dynamic_arg_default(self):
+        self.assert_matches(self.quick_xacro('''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:macro name="dyn_arg" params="name">
+        <xacro:arg name="${name}_test" default="test" />
+        <link name="$(arg ${name}_test)" />
+    </xacro:macro>
+    <xacro:dyn_arg name="a" />
+    <xacro:dyn_arg name="b" />
+</a>'''), '''<a>
+  <link name="test"/>
+  <link name="test"/>
+</a>''')
+
+    def test_dynamic_arg_specified(self):
+        self.assert_matches(self.quick_xacro('''
+<a xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:macro name="dyn_arg" params="name">
+        <xacro:arg name="${name}_test" default="test" />
+        <link name="$(arg ${name}_test)" />
+    </xacro:macro>
+    <xacro:dyn_arg name="a" />
+    <xacro:dyn_arg name="b" />
+</a>''', cli=['a_test:=test1', 'b_test:=test2']), '''<a>
+  <link name="test1"/>
+  <link name="test2"/>
+</a>''')
+
     def test_broken_include_error_reporting(self):
         self.assertRaises(xml.parsers.expat.ExpatError, self.quick_xacro,
         '''<a xmlns:xacro="http://www.ros.org/wiki/xacro">

--- a/xacro/__init__.py
+++ b/xacro/__init__.py
@@ -952,6 +952,7 @@ def eval_all(node, macros, symbols):
 
             elif node.tagName == 'xacro:arg':
                 name, default = check_attrs(node, ['name', 'default'], [])
+                name = str(eval_text(name, symbols))
                 if name not in substitution_args_context['arg']:
                     substitution_args_context['arg'][name] = str(eval_text(default, symbols))
 


### PR DESCRIPTION
This PR allows a macro to specify args whose names are defined by the macro params, e.g.

```XML
<xacro:macro name="test" params="name">
  <xacro:arg name="${name}_arg" default="test" />
  <link name="$(arg ${name}_arg)" />
</xacro:macro>
<xacro:test name="a" />
```

This Xacro snippet defines argument `a_arg` which can be either defaulted or read from CLI args.

Without this PR, the above specification works only when the arg is passed from CLI and it doesn't work when the default should have been used.

I know this is a bit of double evaluation, but this one seems pretty useful to me. The use-case I'd like to get is a general macro for calibrated joints like this one:

    <xacro:macro name="calibrated_fixed_joint" params="name parent child prefix:='' lump:='1'">
        <xacro:if value="${prefix == ''}">
            <xacro:property name="pref" value="${child}" />
        </xacro:if>
        <xacro:if value="${prefix != ''}">
            <xacro:property name="pref" value="${prefix}" />
        </xacro:if>
        <xacro:arg name="${pref}_pos_x" default="0.0" />
        <xacro:arg name="${pref}_pos_y" default="0.0" />
        <xacro:arg name="${pref}_pos_" default="0.0" />
        <xacro:arg name="${pref}_rpy_r" default="0.0" />
        <xacro:arg name="${pref}_rpy_p" default="0.0" />
        <xacro:arg name="${pref}_rpy_y" default="0.0" />
        <xacro:fixed_joint name="${name}" parent="$(arg prefix)${parent}" child="$(arg prefix)${child}"
                           xyz="$(arg ${pref}_pos_x) $(arg ${pref}_pos_y) $(arg ${pref}_pos_z)"
                           rpy="$(arg ${pref}_rpy_r) $(arg ${pref}_rpy_p) $(arg ${pref}_rpy_y)"
                           lump="${lump}"/>
    </xacro:macro>